### PR TITLE
893596 - sending up baseurl of repos from katello-agent

### DIFF
--- a/src/katello/agent/katelloplugin.py
+++ b/src/katello/agent/katelloplugin.py
@@ -259,7 +259,7 @@ class EnabledReport:
             fn = os.path.basename(r.repofile)
             if fn != repofn:
                 continue
-            item = dict(repositoryid=r.id)
+            item = dict(repositoryid=r.id, baseurl=r.baseurl)
             enabled.append(item)
         return dict(repos=enabled)
 


### PR DESCRIPTION
repositories cannot be identified from just the repositoryid, 
we must send up the full baseurl in order to identify them.
