### PR TITLE
Fix agent requirements for pulp 2.4; catch and report errors sending the enabled report.

### DIFF
--- a/katello-agent.spec
+++ b/katello-agent.spec
@@ -11,9 +11,10 @@ BuildArch: noarch
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 BuildRequires: rpm-python
-Requires: gofer >= 1.0.10
-Requires: python-pulp-agent-lib >= 2.0.5
-Requires: pulp-rpm-handlers >= 2.0.5
+Requires: gofer >= 1.0.12
+Requires: python-gofer-qpid >= 1.0.12
+Requires: python-pulp-agent-lib >= 2.4.0
+Requires: pulp-rpm-handlers >= 2.4.0
 Requires: subscription-manager
 
 %description

--- a/src/katello/agent/katelloplugin.py
+++ b/src/katello/agent/katelloplugin.py
@@ -94,10 +94,13 @@ def send_enabled_report(path=REPOSITORY_PATH):
     if not ConsumerIdentity.existsAndValid():
         # not registered
         return
-    uep = UEP()
-    certificate = ConsumerIdentity.read()
-    report = EnabledReport(path)
-    uep.report_enabled(certificate.getConsumerId(), report.content)
+    try:
+        uep = UEP()
+        certificate = ConsumerIdentity.read()
+        report = EnabledReport(path)
+        uep.report_enabled(certificate.getConsumerId(), report.content)
+    except Exception, e:
+        log.error('send enabled report failed: %s', str(e))
 
 
 def setup_plugin():

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -135,6 +135,28 @@ class TestSendEnabledReport(PluginTest):
         self.assertFalse(fake_report.called)
         self.assertFalse(fake_uep.called)
 
+    @patch('katello.agent.katelloplugin.UEP')
+    @patch('katello.agent.katelloplugin.EnabledReport')
+    @patch('katello.agent.katelloplugin.ConsumerIdentity.read')
+    @patch('katello.agent.katelloplugin.ConsumerIdentity.existsAndValid')
+    def test_send_and_failed(self, fake_valid, fake_read, fake_report, fake_uep):
+        path = '/tmp/path/test'
+        consumer_id = '1234'
+        fake_certificate = Mock()
+        fake_certificate.getConsumerId.return_value = consumer_id
+        fake_valid.return_value = True
+        fake_read.return_value = fake_certificate
+        fake_uep().report_enabled.side_effect = ValueError()
+
+        # test
+        self.plugin.send_enabled_report(path)
+
+        # validation
+        fake_valid.assert_called_with()
+        fake_report.assert_called_with(path)
+        fake_certificate.getConsumerId.assert_called_with()
+        fake_uep().report_enabled.assert_called_with(consumer_id, fake_report().content)
+
 
 class TestSetupPlugin(PluginTest):
 


### PR DESCRIPTION
python-gofer-qpid needed for qpid support in gofer 1.0 which supports multiple transports.  Qpid support no longer included in python-gofer.

Catch and report errors raised when reporting the enabled repositories.
