### PR TITLE
fixes #6103 - updating package profile after every yum action

### DIFF
--- a/bin/katello-package-upload
+++ b/bin/katello-package-upload
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+import sys
+sys.path.append('/usr/lib/yum-plugins')
+
+import package_upload
+
+
+def main():
+    package_upload.upload_package_profile()
+
+if __name__ == "__main__":
+    main()
+

--- a/etc/yum/pluginconf.d/package_upload.conf
+++ b/etc/yum/pluginconf.d/package_upload.conf
@@ -1,0 +1,3 @@
+[main]
+enabled=1
+

--- a/katello-agent.spec
+++ b/katello-agent.spec
@@ -37,6 +37,15 @@ mkdir -p %{buildroot}/%{_prefix}/lib/gofer/plugins
 cp etc/gofer/plugins/katelloplugin.conf %{buildroot}/%{_sysconfdir}/gofer/plugins
 cp src/katello/agent/katelloplugin.py %{buildroot}/%{_prefix}/lib/gofer/plugins
 
+mkdir -p %{buildroot}/%{_prefix}/lib/yum-plugins
+cp src/yum-plugins/package_upload.py %{buildroot}/%{_prefix}/lib/yum-plugins
+
+mkdir -p %{buildroot}/%{_sysconfdir}/yum/pluginconf.d/
+cp etc/yum/pluginconf.d/package_upload.conf %{buildroot}/%{_sysconfdir}/yum/pluginconf.d/package_upload.conf
+
+mkdir -p %{buildroot}%{_sbindir}
+cp bin/katello-package-upload %{buildroot}%{_sbindir}/katello-package-upload
+
 %clean
 rm -rf %{buildroot}
 
@@ -46,6 +55,10 @@ LC_ALL=C service goferd status | grep 'is running' && service goferd restart
 %files
 %config(noreplace) %{_sysconfdir}/gofer/plugins/katelloplugin.conf
 %{_prefix}/lib/gofer/plugins/katelloplugin.*
+%{_sysconfdir}/yum/pluginconf.d/package_upload.conf
+%attr(750, root, root) %{_sbindir}/katello-package-upload
+%{_prefix}/lib/yum-plugins
+
 %doc LICENSE
 
 %changelog

--- a/src/yum-plugins/package_upload.py
+++ b/src/yum-plugins/package_upload.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+import sys
+sys.path.append('/usr/share/rhsm')
+
+from yum.plugins import PluginYumExit, TYPE_CORE, TYPE_INTERACTIVE
+
+from subscription_manager import certmgr
+from subscription_manager.certlib import ConsumerIdentity
+from rhsm import connection
+
+try:
+    from subscription_manager.injectioninit import init_dep_injection
+    init_dep_injection()
+except ImportError:
+    pass
+
+requires_api_version = '2.3'
+plugin_type = (TYPE_CORE, TYPE_INTERACTIVE)
+
+def upload_package_profile():
+    uep = connection.UEPConnection(cert_file=ConsumerIdentity.certpath(),
+                                   key_file=ConsumerIdentity.keypath())
+    mgr = certmgr.CertManager(uep=uep)
+    mgr.profilelib._do_update()
+
+def posttrans_hook(conduit):
+    conduit.info(2, "Uploading Package Profile")
+    try:
+        upload_package_profile()
+    except:
+        conduit.error(2, "Unable to upload Package Profile")
+


### PR DESCRIPTION
This commit does two things:
- Adds a yum plugin 'package_upload' which sends the package profile up
    after every yum rpm transaction.  So this handles yum actions initiated
    from katello and actions run on the client using 'yum'
- Includes a new executable 'katello-package-upload' which force pushes the package profile

TODO
- [ ] Test on el5
