### PR TITLE
Fixes #7553: Update ConsumerIdentity location.

### DIFF
--- a/src/katello/agent/katelloplugin.py
+++ b/src/katello/agent/katelloplugin.py
@@ -30,7 +30,7 @@ from gofer.pmon import PathMonitor
 from gofer.agent.rmi import Context
 from gofer.config import Config
 
-from subscription_manager.certlib import ConsumerIdentity
+from subscription_manager.identity import ConsumerIdentity
 from rhsm.connection import UEPConnection
 
 from pulp.agent.lib.dispatcher import Dispatcher

--- a/src/yum-plugins/package_upload.py
+++ b/src/yum-plugins/package_upload.py
@@ -17,7 +17,7 @@ sys.path.append('/usr/share/rhsm')
 from yum.plugins import PluginYumExit, TYPE_CORE, TYPE_INTERACTIVE
 
 from subscription_manager import certmgr
-from subscription_manager.certlib import ConsumerIdentity
+from subscription_manager.identity import ConsumerIdentity
 from rhsm import connection
 
 try:


### PR DESCRIPTION
Subscription manager library moved the location of ConsumerIdentity
that katello-agent relies on. Instead of being at:

subscription_manager.certlib

The ConsumerIdentity class looks like it is located at:

subscription_manager.identity

This fix should work for all versions of subscription-manager, not just
the latest.
