### PR TITLE
Fixes #22330 - Always run cron after reboot

### DIFF
--- a/extra/katello-agent-send.cron
+++ b/extra/katello-agent-send.cron
@@ -1,2 +1,2 @@
 # Send a new Tracer report after a reboot
-@reboot root /sbin/katello-tracer-upload > /dev/null 2>&1
+@reboot root sleep 60 && /sbin/katello-tracer-upload > /dev/null 2>&1


### PR DESCRIPTION
I suspect this isn't working for some people because if it runs before the network is up, it will not work. 

I think we should either add this sleep or instead create a systemd-timer unit, with proper dependencies. 