### PR TITLE
Support DNF and pulp handler.  closes #21904.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-*.pyc
+*.py[co]
 *.swp
 *.swo
+src/build
+src/dist
+src/katello_agent.egg-info/
 test/data

--- a/etc/gofer/plugins/katello.conf
+++ b/etc/gofer/plugins/katello.conf
@@ -46,6 +46,7 @@
 [main]
 enabled=1
 latency=1
+plugin=katello.agent.goferd.plugin
 
 [messaging]
 url=

--- a/src/katello/agent/goferd/plugin.py
+++ b/src/katello/agent/goferd/plugin.py
@@ -15,27 +15,23 @@
 The katello virtual agent.
 Provides content management APIs for pulp within the RHSM environment.
 """
-
 import os
 import sys
-import httplib
 
 sys.path.append('/usr/share/rhsm')
-sys.path.append('/usr/lib/yum-plugins')
 
 from time import sleep
 from logging import getLogger
 from subprocess import Popen
 
+from six.moves import http_client as http
+
 from katello.constants import REPOSITORY_PATH
 
-from gofer.decorators import initializer, remote, action
+from gofer.decorators import initializer, remote, action, FORK
 from gofer.agent.plugin import Plugin
 from gofer.pmon import PathMonitor
-from gofer.agent.rmi import Context
 from gofer.config import Config
-
-import enabled_repos_upload
 
 try:
     from subscription_manager.identity import ConsumerIdentity
@@ -44,8 +40,9 @@ except ImportError:
 
 from rhsm.connection import UEPConnection, RemoteServerException
 
-from pulp.agent.lib.dispatcher import Dispatcher
-from pulp.agent.lib.conduit import Conduit as HandlerConduit
+from katello.agent.pulp import Dispatcher
+from katello.enabled_report import EnabledReport
+from katello.repos import upload_enabled_repos_report
 
 
 # This plugin
@@ -84,7 +81,7 @@ def init_plugin():
                 update_settings()
             # DONE
             break
-        except Exception, e:
+        except Exception as e:
             log.warn(str(e))
             sleep(60)
 
@@ -127,13 +124,15 @@ def certificate_changed(path):
                 plugin.detach()
             # DONE
             break
-        except Exception, e:
+        except Exception as e:
             log.warn(str(e))
             sleep(60)
 
+
 def send_enabled_report(path=REPOSITORY_PATH):
-    report = enabled_repos_upload.EnabledReport(path)
-    enabled_repos_upload.upload_enabled_repos_report(report)
+    report = EnabledReport(path)
+    upload_enabled_repos_report(report)
+
 
 def update_settings():
     """
@@ -141,12 +140,12 @@ def update_settings():
     """
     rhsm_conf = Config(RHSM_CONFIG_PATH)
     certificate = ConsumerIdentity.read()
-    if rhsm_conf['rhsm'].has_key('ca_cert_dir'):
+    if 'ca_cert_dir' in rhsm_conf['rhsm']:
         ca_cert_dir = rhsm_conf['rhsm']['ca_cert_dir']
     else:
         #handle old subscription-manager configurations
         ca_cert_dir = rhsm_conf['server']['ca_cert_dir']
- 
+
     # the 'katello-default-ca.pem' is the ca used for generating the CA certs.
     # the 'candlepin-local.pem' is there for compatibility reasons (the old path where the
     # legacy installer was putting this file. If none of them is present, there is still
@@ -187,11 +186,11 @@ def validate_registration():
         uep = UEP()
         consumer = uep.getConsumer(consumer_id)
         registered = (consumer is not None)
-    except RemoteServerException, e:
-        if e.code != httplib.NOT_FOUND:
+    except RemoteServerException as e:
+        if e.code != http.NOT_FOUND:
             log.warn(str(e))
             raise
-    except Exception, e:
+    except Exception as e:
         log.exception(str(e))
         raise
 
@@ -252,41 +251,6 @@ class AgentRestart(object):
         log.error('Restart failed, exit=%d', exit_val)
 
 
-class Conduit(HandlerConduit):
-    """
-    Provides integration between the gofer and pulp agent handler frameworks.
-    """
-
-    @property
-    def consumer_id(self):
-        """
-        Get the current consumer ID
-        :return: The unique consumer ID of the currently running agent
-        :rtype:  str
-        """
-        certificate = ConsumerIdentity.read()
-        return certificate.getConsumerId()
-
-    def update_progress(self, report):
-        """
-        This method inentionally left blank mitigate Qpid journal
-        latency related to AMQP 1.0.  The latency significantly
-        degrades performance. If a better solution is found we
-        may re-enable this method to actually report back progress.
-        See http://projects.theforeman.org/issues/12375
-        :param report: A handler progress report.
-        :type report: object
-        """
-
-    def cancelled(self):
-        """
-        Get whether the current operation has been cancelled.
-        :return: True if cancelled, else False.
-        :rtype: bool
-        """
-        context = Context.current()
-        return context.cancelled()
-
 class UEP(UEPConnection):
     """
     Represents the UEP.
@@ -306,7 +270,9 @@ class Consumer(object):
 
     @remote
     def unregister(self):
-        log.info('Consumer has been unregistered. Katello agent will no longer function until this system is reregistered.')
+        log.info('Consumer has been unregistered. '
+                 'Katello agent will no longer function until '
+                 'this system is reregistered.')
 
 
 class Content(object):
@@ -314,7 +280,7 @@ class Content(object):
     Pulp Content Management.
     """
 
-    @remote
+    @remote(model=FORK)
     def install(self, units, options):
         """
         Install the specified content units using the specified options.
@@ -327,12 +293,11 @@ class Content(object):
         :return: A dispatch report.
         :rtype: DispatchReport
         """
-        conduit = Conduit()
         dispatcher = Dispatcher()
-        report = dispatcher.install(conduit, units, options)
+        report = dispatcher.install(units, options)
         return report.dict()
 
-    @remote
+    @remote(model=FORK)
     def update(self, units, options):
         """
         Update the specified content units using the specified options.
@@ -345,12 +310,11 @@ class Content(object):
         :return: A dispatch report.
         :rtype: DispatchReport
         """
-        conduit = Conduit()
         dispatcher = Dispatcher()
-        report = dispatcher.update(conduit, units, options)
+        report = dispatcher.update(units, options)
         return report.dict()
 
-    @remote
+    @remote(model=FORK)
     def uninstall(self, units, options):
         """
         Uninstall the specified content units using the specified options.
@@ -363,7 +327,6 @@ class Content(object):
         :return: A dispatch report.
         :rtype: DispatchReport
         """
-        conduit = Conduit()
         dispatcher = Dispatcher()
-        report = dispatcher.uninstall(conduit, units, options)
+        report = dispatcher.uninstall( units, options)
         return report.dict()

--- a/src/katello/agent/pulp/__init__.py
+++ b/src/katello/agent/pulp/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .dispatcher import Dispatcher

--- a/src/katello/agent/pulp/dispatcher.py
+++ b/src/katello/agent/pulp/dispatcher.py
@@ -1,0 +1,178 @@
+from gettext import gettext as _
+from logging import getLogger
+
+from katello.agent.pulp.handler import PackageHandler, GroupHandler, ErratumHandler
+from katello.agent.pulp.report import DispatchReport, HandlerReport
+
+
+log = getLogger(__name__)
+
+
+# Handler Roles
+SYSTEM = 0
+CONTENT = 1
+
+
+class HandlerNotFound(Exception):
+    """
+    Handler not found.
+    """
+
+    def __init__(self, **criteria):
+        """
+        @param criteria: The handler search criteria.
+        @type criteria: dict
+        """
+        Exception.__init__(self, criteria)
+
+    def __str__(self):
+        return _('No handler for: {c}'.format(self.args[0]))
+
+
+class Dispatcher(object):
+    """
+    The dispatch delegates operations to handlers based on
+    the type_id specified in the request.
+    """
+
+    # Handler mapping.
+    handler = {}
+
+    @staticmethod
+    def collated(units):
+        """
+        Content units collated by type_id.
+
+        Args:
+            units (collections.Iterable): A list of content units.
+
+        Returns:
+            dict: Units collated by type_id.
+        """
+        collated = {}
+        for unit in units:
+            type_id = unit['type_id']
+            _list = collated.setdefault(type_id, [])
+            _list.append(unit['unit_key'])
+        return collated
+
+    def install(self, units, options):
+        """
+        Install content.
+
+        Args:
+            units (collections.Iterable): Content to be installed.
+            options (dict): Handler specific options.
+
+        Returns:
+            DispatchReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        dispatch_report = DispatchReport()
+        collated = self.collated(units)
+        for type_id, units in collated.items():
+            try:
+                handler = self.find_handler(type_id, CONTENT)
+                _report = handler.install(units, dict(options))
+                _report.aggregation_key = type_id
+                _report.update(dispatch_report)
+            except Exception:
+                log.exception(_('Handler failed.'))
+                _report = HandlerReport()
+                _report.aggregation_key = type_id
+                _report.set_failed(HandlerReport.last_exception())
+                _report.update(dispatch_report)
+        return dispatch_report
+
+    def update(self, units, options):
+        """
+        Update content.
+
+        Args:
+            units (collections.Iterable): Content to be updated.
+            options (dict): Handler specific options.
+
+        Returns:
+            DispatchReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        dispatch_report = DispatchReport()
+        collated = self.collated(units)
+        for type_id, units in collated.items():
+            try:
+                handler = self.find_handler(type_id, CONTENT)
+                _report = handler.update(units, dict(options))
+                _report.aggregation_key = type_id
+                _report.update(dispatch_report)
+            except Exception:
+                log.exception(_('Handler failed.'))
+                _report = HandlerReport()
+                _report.aggregation_key = type_id
+                _report.set_failed(HandlerReport.last_exception())
+                _report.update(dispatch_report)
+        return dispatch_report
+
+    def uninstall(self, units, options):
+        """
+        Uninstall content.
+
+        Args:
+            units (collections.Iterable): Content to be uninstalled.
+            options (dict): Handler specific options.
+
+        Returns:
+            DispatchReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        dispatch_report = DispatchReport()
+        collated = self.collated(units)
+        for type_id, units in collated.items():
+            try:
+                handler = self.find_handler(type_id, CONTENT)
+                _report = handler.uninstall(units, dict(options))
+                _report.aggregation_key = type_id
+                _report.update(dispatch_report)
+            except Exception:
+                log.exception(_('Handler failed.'))
+                _report = HandlerReport()
+                _report.aggregation_key = type_id
+                _report.set_failed(HandlerReport.last_exception())
+                _report.update(dispatch_report)
+        return dispatch_report
+
+    def find_handler(self, type_id, role):
+        """
+        Find a handler by type ID and role.
+
+        Args:
+            type_id (int): A content type ID.
+            role (int): The handler role requested.
+
+        Returns:
+            Handler: The requested handler.
+
+        Raises:
+            HandlerNotFound: When not found.
+        """
+        try:
+            handler = self.handler[role][type_id]
+        except KeyError:
+            raise HandlerNotFound(type=type_id)
+        else:
+            return handler()
+
+
+# Handler Registration.
+Dispatcher.handler = {
+    CONTENT: {
+        'rpm': PackageHandler,
+        'package_group': GroupHandler,
+        'erratum': ErratumHandler,
+    }
+}

--- a/src/katello/agent/pulp/handler.py
+++ b/src/katello/agent/pulp/handler.py
@@ -1,0 +1,280 @@
+from __future__ import absolute_import
+
+
+from logging import getLogger
+
+from katello.agent.pulp.report import ContentReport
+
+try:
+    from .libdnf import Package, PackageGroup, Pattern
+except ImportError:
+    from .libyum import Package, PackageGroup, Pattern
+
+
+log = getLogger(__name__)
+
+
+class ContentHandler(object):
+    """
+    <Abstract> Content handler.
+    Defines the interface for handlers designed to implement CONTENT management requests.
+    """
+
+    def install(self, units, options):
+        """
+        Install content.
+
+        Args:
+            units (collections.Iterable): Content to be installed.
+            options (dict): Handler specific options.
+
+        Returns:
+            DispatchReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        raise NotImplementedError()
+
+    def update(self, units, options):
+        """
+        Update content.
+
+        Args:
+            units (collections.Iterable): Content to be updated.
+            options (dict): Handler specific options.
+
+        Returns:
+            DispatchReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        raise NotImplementedError()
+
+    def uninstall(self, units, options):
+        """
+        Uninstall content.
+
+        Args:
+            units (collections.Iterable): Content to be uninstalled.
+            options (dict): Handler specific options.
+
+        Returns:
+            DispatchReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        raise NotImplementedError()
+
+
+class PackageReport(ContentReport):
+    """
+    Package (install|update|uninstall) report.
+    Calculates the num_changes.
+    """
+
+    def set_succeeded(self, details):
+        num_changes = \
+            len(details['resolved']) + \
+            len(details['deps'])
+        super(PackageReport, self).set_succeeded(details, num_changes)
+
+
+class GroupReport(ContentReport):
+    """
+    Package Group (install|update|uninstall) report.
+    Calculates the num_changes.
+    """
+
+    def set_succeeded(self, details):
+        num_changes = \
+            len(details['resolved']) + \
+            len(details['deps'])
+        super(GroupReport, self).set_succeeded(details, num_changes)
+
+
+class PackageHandler(ContentHandler):
+    """
+    The package (rpm) content handler.
+    """
+
+    @staticmethod
+    def _impl(options):
+        commit = options.get('apply', True)
+        impl = Package(commit=commit)
+        return impl
+
+    def install(self, units, options):
+        """
+        Install packages.
+
+        Args:
+            units (collections.Iterable): Packages to be installed.
+            options (dict): Handler specific options.
+
+        Returns:
+            PackageReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        report = PackageReport()
+        package = self._impl(options)
+        patterns = [Pattern(**u) for u in units]
+        details = package.install(patterns)
+        if details['failed']:
+            report.set_failed(details)
+        else:
+            report.set_succeeded(details)
+        return report
+
+    def update(self, units, options):
+        """
+        Update packages.
+
+        Args:
+            units (collections.Iterable): Packages to be updated.
+            options (dict): Handler specific options.
+
+        Returns:
+            PackageReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        report = PackageReport()
+        _all = options.get('all', False)
+        package = self._impl(options)
+        patterns = [Pattern(**u) for u in units]
+        if patterns or _all:
+            details = package.update(patterns)
+            if details['failed']:
+                report.set_failed(details)
+            else:
+                report.set_succeeded(details)
+        return report
+
+    def uninstall(self, units, options):
+        """
+        Uninstall packages.
+
+        Args:
+            units (collections.Iterable): Packages to be uninstalled.
+            options (dict): Handler specific options.
+
+        Returns:
+            PackageReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        report = PackageReport()
+        package = self._impl(options)
+        patterns = [Pattern(**u) for u in units]
+        details = package.uninstall(patterns)
+        if details['failed']:
+            report.set_failed(details)
+        else:
+            report.set_succeeded(details)
+        return report
+
+
+class GroupHandler(ContentHandler):
+    """
+    The package group content handler.
+    """
+
+    @staticmethod
+    def _impl(options):
+        commit = options.get('apply', True)
+        impl = PackageGroup(commit=commit)
+        return impl
+
+    def install(self, units, options):
+        """
+        Install package group.
+
+        Args:
+            units (collections.Iterable): Groups to be installed.
+            options (dict): Handler specific options.
+
+        Returns:
+            GroupReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        report = GroupReport()
+        group = self._impl(options)
+        names = [key['name'] for key in units]
+        details = group.install(names)
+        report.set_succeeded(details)
+        return report
+
+    def update(self, units, options):
+        raise NotImplementedError()
+
+    def uninstall(self, units, options):
+        """
+        Uninstall packages.
+
+        Args:
+            units (collections.Iterable): Groups to be uninstalled.
+            options (dict): Handler specific options.
+
+        Returns:
+            GroupReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        report = GroupReport()
+        group = self._impl(options)
+        names = [key['name'] for key in units]
+        details = group.uninstall(names)
+        report.set_succeeded(details)
+        return report
+
+
+class ErratumHandler(ContentHandler):
+    """
+    The package (rpm) content handler.
+    """
+
+    @staticmethod
+    def _impl(options):
+        commit = options.get('apply', True)
+        impl = Package(commit=commit)
+        return impl
+
+    def install(self, units, options):
+        """
+        Install Errata.
+
+        Args:
+            units (collections.Iterable): Errata to be installed.
+            options (dict): Handler specific options.
+
+        Returns:
+            PackageReport: A report.
+
+        Notes:
+            Unit is: {type_id:<str>, unit_key:<dict>}
+        """
+        report = PackageReport()
+        package = self._impl(options)
+        advisories = [unit_key['id'] for unit_key in units]
+        details = package.update(advisories=advisories)
+        if details['failed']:
+            report.set_failed(details)
+        else:
+            report.set_succeeded(details)
+        return report
+
+    def update(self, units, options):
+        raise NotImplementedError()
+
+    def uninstall(self, units, options):
+        raise NotImplementedError()

--- a/src/katello/agent/pulp/libdnf.py
+++ b/src/katello/agent/pulp/libdnf.py
@@ -1,0 +1,549 @@
+import logging
+
+import dnf
+import hawkey
+
+
+from gettext import gettext as _
+
+from dnf.exceptions import CompsError
+
+
+log = logging.getLogger('__file__')
+
+
+class Pattern(object):
+    """
+    Package matching pattern.
+
+    Attributes:
+        name (str): Name.
+        epoch (str): Epoch.
+        version (str): Version.
+        release (str): Release.
+        arch (str) Arch..
+    """
+
+    __slots__ = (
+        'name',
+        'epoch',
+        'version',
+        'release',
+        'arch',
+    )
+
+    FIELDS = (
+        ('epoch', ('', ':')),
+        ('name', ('', '')),
+        ('version', ('-', '')),
+        ('release', ('-', '')),
+        ('arch', ('.', '')),
+    )
+
+    def __init__(self, name, epoch='', version='', release='', arch=''):
+        """
+        NEVRA
+
+        Args:
+            name (str): Name.
+            epoch (str): Epoch.
+            version (str): Version.
+            release (str): Release.
+            arch (str) Arch.
+        """
+        self.name = name
+        self.epoch = epoch
+        self.version = version
+        self.release = release
+        self.arch = arch
+
+    def __str__(self):
+        pattern = []
+        for name, sep in self.FIELDS:
+            value = getattr(self, name)
+            if not value:
+                continue
+            if sep[0]:
+                pattern.append(sep[0])
+            pattern.append(value)
+            if sep[1]:
+                pattern.append(sep[1])
+        return ''.join(pattern)
+
+
+class API(object):
+    """
+    Abstract package management API.
+
+    Attributes:
+        commit (bool): Commit the transaction.
+    """
+
+    def __init__(self, commit=True):
+        """
+        Args:
+            commit (bool): Commit the transaction.
+                Use False for a "dry run".
+        """
+        self.commit = commit
+
+
+class TransactionReport(object):
+    """
+    DNF transaction report.
+    """
+
+    def __init__(self, transaction):
+        """
+        Args:
+            transaction: A DNF transaction.
+        """
+        self.resolved = []
+        self.failed = []
+        for item in transaction:
+            po = item.installed or item.erased
+            if po:
+                _list = self.resolved
+            else:
+                _list = self.failed
+            package = dict(
+                qname=str(po),
+                repoid=po.repoid,
+                name=po.name,
+                version=po.version,
+                release=po.release,
+                arch=po.arch,
+                epoch=po.epoch)
+            _list.append(package)
+
+    def dict(self):
+        """
+        Dictionary representation.
+
+        Returns:
+            dict: self
+        """
+        return {
+            'resolved': self.resolved,
+            'failed': self.failed,
+            'deps': [],
+        }
+
+    def log(self, heading):
+        """
+        Log the report.
+
+        Args:
+            heading (str): Log entry heading.
+        """
+        if not self:
+            return
+        names = [p['qname'] for p in self.resolved]
+        _list = ''.join(['\n  {}'.format(n) for n in names])
+        if _list:
+            log.info(heading.format(_list))
+
+    def __len__(self):
+        return len(self.resolved)
+
+
+class InstallTxReport(TransactionReport):
+    """
+    Install transaction report.
+    """
+
+    HEADING = _('\nInstalled:{}')
+
+    def log(self, heading=HEADING):
+        """
+        Log the report.
+
+        Args:
+            heading (str): Log entry heading.
+        """
+        super(InstallTxReport, self).log(heading)
+
+
+class UpdateTxReport(TransactionReport):
+    """
+    Update transaction report.
+    """
+
+    HEADING = _('\nUpdated:{}')
+
+    def log(self, heading=HEADING):
+        """
+        Log the report.
+
+        Args:
+            heading (str): Log entry heading.
+        """
+        super(UpdateTxReport, self).log(heading)
+
+
+class EraseTxReport(TransactionReport):
+    """
+    Erase transaction report.
+    """
+
+    HEADING = _('\nErased:{}')
+
+    def log(self, heading=HEADING):
+        """
+        Log the report.
+
+        Args:
+            heading (str): Log entry heading.
+        """
+        super(EraseTxReport, self).log(heading)
+
+
+class Package(API):
+    """
+    The package management API.
+    """
+
+    def install(self, patterns):
+        """
+        Install packages.
+
+        Args:
+            patterns (collections.Iterable): A list of Pattern.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibDnf() as lib:
+            lib.install(str(p) for p in patterns)
+            if self.commit:
+                lib.do_transaction()
+            report = InstallTxReport(lib.transaction)
+            if self.commit:
+                report.log()
+        return report.dict()
+
+    def update(self, patterns=(), advisories=()):
+        """
+        Update packages.
+
+        Args:
+            patterns (collections.Iterable): A list of Pattern.
+            advisories (collections.Iterable): A list of advisory IDs.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibDnf() as lib:
+            patterns = set(str(p) for p in patterns)
+            if advisories:
+                for ad, packages in lib.applicable_advisories(AdvisoryFilter(ids=advisories)):
+                    for name, evr in packages:
+                        patterns.add(name)
+                if patterns:
+                    lib.upgrade(patterns)
+            else:
+                lib.upgrade(patterns)
+            if self.commit:
+                lib.do_transaction()
+            report = UpdateTxReport(lib.transaction or ())
+            if self.commit:
+                report.log()
+        return report.dict()
+
+    def uninstall(self, patterns):
+        """
+        Uninstall (remove) packages.
+
+        Args:
+            patterns (collections.Iterable): A list of Pattern.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibDnf() as lib:
+            lib.remove(str(p) for p in patterns)
+            if self.commit:
+                lib.do_transaction()
+            report = EraseTxReport(lib.transaction)
+            if self.commit:
+                report.log()
+        return report.dict()
+
+
+class PackageGroup(API):
+    """
+    Package group management API.
+    """
+
+    @staticmethod
+    def _resolved(lib, names):
+        """
+        Resolve group names to IDs.
+
+        Args:
+            lib (LibDnf): An opened lib.
+            names (collections.Iterable): A list of group names.
+
+        Yields:
+            Group IDs.
+
+        Raises:
+            CompsError: When name cannot be resolved.
+        """
+        for p in names:
+            group = lib.comps.group_by_pattern(p)
+            if not group:
+                raise CompsError(_('Group "{g}" not found.').format(g=p))
+            else:
+                yield group.id
+
+    def install(self, names):
+        """
+        Install package groups.
+
+        Args:
+            names (collections.Iterable): A list of group names.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibDnf() as lib:
+            lib.group_install(self._resolved(lib, names))
+            if self.commit:
+                lib.do_transaction()
+            report = InstallTxReport(lib.transaction)
+            if self.commit:
+                report.log()
+        return report.dict()
+
+    def uninstall(self, names):
+        """
+        Uninstall package groups.
+
+        Args:
+            names (collections.Iterable): A list of group names.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibDnf() as lib:
+            lib.group_remove(self._resolved(lib, names))
+            if self.commit:
+                lib.do_transaction()
+            report = EraseTxReport(lib.transaction)
+            if self.commit:
+                report.log()
+        return report.dict()
+
+
+class AdvisoryFilter(object):
+    """
+    Advisory filter.
+
+    Filter by advisory IDs and/or types.
+    """
+
+    LABEL2TYPE = {
+        _('BUGFIX'): hawkey.ADVISORY_BUGFIX,
+        _('ENHANCEMENT'): hawkey.ADVISORY_ENHANCEMENT,
+        _('SECURITY'): hawkey.ADVISORY_SECURITY,
+        _('UNKNOWN'): hawkey.ADVISORY_UNKNOWN,
+    }
+
+    def __init__(self, ids=(), types=()):
+        """
+        Args:
+            ids (collections.Iterable): List of advisory IDs.
+            types (collections.Iterable): List of advisory types.  See: LABEL2TYPE.
+        """
+        self.ids = {s.upper() for s in ids}
+        self.types = {self.LABEL2TYPE.get(s.upper(), hawkey.ADVISORY_UNKNOWN) for s in types}
+
+    def match(self, advisory):
+        """
+        Match advisory.
+
+        Args:
+            advisory: An advisory.
+
+        Returns:
+            bool: True when matched.
+        """
+        if self.ids and (advisory.id.upper() not in self.ids):
+            return False
+        if self.types and (advisory.type not in self.types):
+            return False
+        return True
+
+
+class LibDnf(dnf.Base):
+    """
+    DNF base.
+
+    Notes:
+        Requires dnf >= 2.7.5
+    """
+
+    # Logging cannot be reconfigured.
+    # Plugins cannot be reloaded within the process.
+    __lib_loaded = False
+
+    def __init__(self):
+        """
+        Initialization.
+        """
+        super(LibDnf, self).__init__()
+        self.conf.assumeyes = True
+
+    def open(self):
+        """
+        Open the lib.
+        """
+        self.read_all_repos()
+        if not LibDnf.__lib_loaded:
+            self._logging._setup_from_dnf_conf(self.conf)
+            self.init_plugins()
+            LibDnf.__lib_loaded = True
+        self.fill_sack('auto', True)
+        self._plugins.run_sack()
+        self.read_comps()
+
+    def install(self, patterns):
+        """
+        Install packages specified by the patterns.
+
+        Args:
+            patterns: List of (str) patterns.
+
+        Notes:
+            Need to call do_transaction() to commit the changes.
+        """
+        for p in patterns:
+            super(LibDnf, self).install(p)
+        self.resolve(allow_erasing=False)
+        self._plugins.run_resolved()
+        self._download()
+
+    def upgrade(self, patterns=()):
+        """
+        Upgrade packages specified by the patterns.
+
+        Args:
+            patterns: List of (str) patterns.
+
+        Notes:
+            Need to call do_transaction() to commit the changes.
+        """
+        if patterns:
+            for p in patterns:
+                super(LibDnf, self).upgrade(p)
+        else:
+            self.upgrade_all()
+        self.resolve(allow_erasing=False)
+        self._plugins.run_resolved()
+        self._download()
+
+    def remove(self, patterns):
+        """
+        Remove packages specified by the patterns.
+
+        Args:
+            patterns: List of (str) patterns.
+
+        Notes:
+            Need to call do_transaction() to commit the changes.
+        """
+        for p in patterns:
+            super(LibDnf, self).remove(p)
+        self.resolve(allow_erasing=False)
+        self._plugins.run_resolved()
+
+    def group_install(self, grp_ids):
+        """
+        Install package groups.
+
+        Args:
+            grp_ids: List of (str) group IDs.
+
+        Notes:
+            Need to call do_transaction() to commit the changes.
+        """
+        for grp_id in grp_ids:
+            super(LibDnf, self).group_install(grp_id, ('mandatory', 'default'))
+        self.resolve(allow_erasing=False)
+        self._plugins.run_resolved()
+        self._download()
+
+    def group_remove(self, grp_ids):
+        """
+        Remove package groups.
+
+        Args:
+            grp_ids: List of (str) group IDs.
+
+        Notes:
+            Need to call do_transaction() to commit the changes.
+        """
+        for grp_id in grp_ids:
+            super(LibDnf, self).group_remove(grp_id)
+        self.resolve(allow_erasing=False)
+        self._plugins.run_resolved()
+
+    def list_advisories(self, filter=AdvisoryFilter()):
+        """
+        Get a list of advisories matching the filter.
+
+        Args:
+            filter (AdvisoryFilter): An optional filter.
+
+        Returns:
+            list: The list of matching advisories.
+        """
+        advisories = []
+        query = self.sack.query().filter(upgradable=True)
+        for package in query.installed():
+            for ad in package.get_advisories(hawkey.GT):
+                if filter.match(ad):
+                    advisories.append(ad)
+        return advisories
+
+    def applicable_advisories(self, filter=AdvisoryFilter()):
+        """
+        Get a list of applicable advisories matching the filter.
+
+        Args:
+            filter (AdvisoryFilter): An optional filter.
+
+        Returns:
+            list: The list of applicable advisories.
+        """
+        advisories = []
+        query = self.sack.query()
+        installed = {(p.name, p.arch): p for p in query.installed()}
+        for ad in self.list_advisories(filter):
+            packages = set()
+            for ap in ad.packages:
+                try:
+                    ip = installed[(ap.name, ap.arch)]
+                except KeyError:
+                    continue
+                if self.sack.evr_cmp(ip.evr, ap.evr) < 0:
+                    packages.add((ap.name, ap.evr))
+            if packages:
+                advisories.append((ad, packages))
+        return advisories
+
+    def _download(self):
+        """
+        Download packages as needed.
+        """
+        downloads = []
+        for tx in self.transaction:
+            if tx.installed:
+                downloads.append(tx.installed)
+        self.download_packages(downloads)
+
+    def __enter__(self):
+        super(LibDnf, self).__enter__()
+        self.open()
+        return self

--- a/src/katello/agent/pulp/libyum.py
+++ b/src/katello/agent/pulp/libyum.py
@@ -1,0 +1,411 @@
+import six
+import logging
+
+from itertools import chain
+from gettext import gettext as _
+from optparse import OptionParser
+
+from yum import YumBase
+from yum.plugins import TYPE_CORE, TYPE_INTERACTIVE
+from yum.Errors import InstallError
+from yum import constants
+from yum import updateinfo
+
+
+log = logging.getLogger(__name__)
+logfile = logging.getLogger('yum.filelogging')
+
+
+class Pattern(object):
+    """
+    Package matching pattern.
+
+    Attributes:
+        name (str): Name.
+        epoch (str): Epoch.
+        version (str): Version.
+        release (str): Release.
+        arch (str) Arch..
+    """
+
+    __slots__ = (
+        'name',
+        'epoch',
+        'version',
+        'release',
+        'arch',
+    )
+
+    def __init__(self, name, epoch='*', version='*', release='*', arch='*'):
+        """
+        NEVRA
+
+        Args:
+            name (str): Name.
+            epoch (str): Epoch.
+            version (str): Version.
+            release (str): Release.
+            arch (str) Arch.
+        """
+        self.name = name
+        self.epoch = epoch
+        self.version = version
+        self.release = release
+        self.arch = arch
+
+    def __str__(self):
+        fmt = '{epoch}:{name}-{version}-{release}.{arch}'
+        return fmt.format(
+            epoch=self.epoch,
+            name=self.name,
+            version=self.version,
+            release=self.release,
+            arch=self.arch)
+
+
+class TransactionReport(object):
+    """
+    YUM transaction report.
+    """
+
+    def __init__(self, ts_info, states):
+        """
+        Args:
+            ts_info: A YUM transaction.
+            states: List of package states to be included.
+        """
+        self.deps = []
+        self.resolved = []
+        self.failed = []
+        for t in ts_info:
+            if t.output_state not in states:
+                continue
+            qname = str(t.po)
+            package = dict(
+                qname=qname,
+                repoid=t.repoid,
+                name=t.po.name,
+                version=t.po.ver,
+                release=t.po.rel,
+                arch=t.po.arch,
+                epoch=t.po.epoch)
+            if t.output_state == constants.TS_FAILED:
+                self.failed.append(package)
+            if t.isDep:
+                self.deps.append(package)
+            else:
+                self.resolved.append(package)
+
+    def dict(self):
+        """
+        Dictionary representation.
+
+        Returns:
+            dict: self
+        """
+        return {
+            'resolved': self.resolved,
+            'failed': self.failed,
+            'deps': self.deps,
+        }
+
+    def log(self, heading):
+        """
+        Log the report.
+
+        Args:
+            heading (str): Log entry heading.
+        """
+        if not self:
+            return
+        for qname in [p['qname'] for p in chain(self.resolved, self.deps)]:
+            entry = heading.format(qname)
+            logfile.info(entry)
+            log.info(entry)
+
+    def __len__(self):
+        return len(self.resolved) + len(self.deps)
+
+
+class InstallTxReport(TransactionReport):
+    """
+    Install transaction report.
+    """
+
+    HEADING = _('Installed: {}')
+
+    STATES = (
+        constants.TS_FAILED,
+        constants.TS_INSTALL,
+        constants.TS_TRUEINSTALL,
+        constants.TS_UPDATE
+    )
+
+    def __init__(self, ts_info, states=STATES):
+        """
+        Args:
+            ts_info: A YUM transaction.
+            states: List of package states to be included.
+        """
+        super(InstallTxReport, self).__init__(ts_info, states)
+
+    def log(self, heading=HEADING):
+        """
+        Log the report.
+
+        Args:
+            heading (str): Log entry heading.
+        """
+        super(InstallTxReport, self).log(heading)
+
+
+class UpdateTxReport(TransactionReport):
+    """
+    Update transaction report.
+    """
+
+    HEADING = _('Updated: {}')
+
+    STATES = (
+        constants.TS_FAILED,
+        constants.TS_INSTALL,
+        constants.TS_TRUEINSTALL,
+        constants.TS_UPDATE
+    )
+
+    def __init__(self, ts_info, states=STATES):
+        """
+        Args:
+            ts_info: A YUM transaction.
+            states: List of package states to be included.
+        """
+        super(UpdateTxReport, self).__init__(ts_info, states)
+
+    def log(self, heading=HEADING):
+        """
+        Log the report.
+
+        Args:
+            heading (str): Log entry heading.
+        """
+        super(UpdateTxReport, self).log(heading)
+
+
+class EraseTxReport(TransactionReport):
+    """
+    Erase transaction report.
+    """
+
+    HEADING = _('Erased: {}')
+
+    STATES = (
+        constants.TS_FAILED,
+        constants.TS_ERASE
+    )
+
+    def __init__(self, ts_info, states=STATES):
+        """
+        Args:
+            ts_info: A YUM transaction.
+            states: List of package states to be included.
+        """
+        super(EraseTxReport, self).__init__(ts_info, states)
+
+    def log(self, heading=HEADING):
+        """
+        Log the report.
+
+        Args:
+            heading (str): Log entry heading.
+        """
+        super(EraseTxReport, self).log(heading)
+
+
+class API(object):
+    """
+    Abstract package management API.
+
+    Attributes:
+        commit (bool): Commit the transaction.
+    """
+
+    def __init__(self, commit=True):
+        """
+        Args:
+            commit (bool): Commit the transaction.
+                Use False for a "dry run".
+        """
+        self.commit = commit
+
+
+class Package(API):
+    """
+    The package management API.
+    """
+
+    def install(self, patterns):
+        """
+        Install packages.
+
+        Args:
+            patterns (collections.Iterable): A list of Pattern.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibYum() as lib:
+            for pattern in patterns:
+                try:
+                    lib.install(pattern=str(pattern))
+                except InstallError as caught:
+                    description = six.text_type(caught).encode('utf-8')
+                    caught.value = '%s: %s' % (pattern, description)
+                    raise caught
+            lib.resolveDeps()
+            if self.commit and len(lib.tsInfo):
+                lib.processTransaction()
+            report = InstallTxReport(lib.tsInfo)
+            if self.commit:
+                report.log()
+            return report.dict()
+
+    def update(self, patterns=(), advisories=()):
+        """
+        Update packages.
+
+        Args:
+            patterns (collections.Iterable): A list of Pattern.
+            advisories (collections.Iterable): A list of advisory IDs.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibYum() as lib:
+            if advisories:
+                lib.updateinfo_filters = {
+                    'bzs': [],
+                    'bugfix': None,
+                    'sevs': [],
+                    'security': None,
+                    'advs': advisories,
+                    'cves': []
+                }
+                updateinfo.update_minimal(lib)
+            if patterns:
+                for pattern in patterns:
+                    lib.update(pattern=str(pattern))
+            else:
+                lib.update()
+            lib.resolveDeps()
+            if self.commit and len(lib.tsInfo):
+                lib.processTransaction()
+            report = UpdateTxReport(lib.tsInfo)
+            if self.commit:
+                report.log()
+            return report.dict()
+
+    def uninstall(self, patterns):
+        """
+        Uninstall (remove) packages.
+
+        Args:
+            patterns (collections.Iterable): A list of Pattern.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibYum() as lib:
+            for pattern in patterns:
+                lib.remove(pattern=str(pattern))
+            lib.resolveDeps()
+            if self.commit and len(lib.tsInfo):
+                lib.processTransaction()
+            report = EraseTxReport(lib.tsInfo)
+            if self.commit:
+                report.log()
+            return report.dict()
+
+
+class PackageGroup(API):
+    """
+    Package group management API.
+    """
+
+    def install(self, names):
+        """
+        Install package groups.
+
+        Args:
+            names (collections.Iterable): A list of group names.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibYum() as lib:
+            for name in names:
+                lib.selectGroup(name)
+            lib.resolveDeps()
+            if self.commit and len(lib.tsInfo):
+                lib.processTransaction()
+            report = InstallTxReport(lib.tsInfo)
+            if self.commit:
+                report.log()
+            return report.dict()
+
+    def uninstall(self, names):
+        """
+        Uninstall package groups.
+
+        Args:
+            names (collections.Iterable): A list of group names.
+
+        Returns:
+            dict: A dictionary representation of a TransactionReport.
+        """
+        with LibYum() as lib:
+            for name in names:
+                lib.groupRemove(name)
+            lib.resolveDeps()
+            if self.commit and len(lib.tsInfo):
+                lib.processTransaction()
+            report = EraseTxReport(lib.tsInfo)
+            if self.commit:
+                report.log()
+            return report.dict()
+
+
+class LibYum(YumBase):
+    """
+    A YUM base.
+    """
+
+    def __init__(self):
+        """
+        Initialization.
+        """
+        parser = OptionParser()
+        parser.parse_args([])
+        self.__parser = parser
+        super(LibYum, self).__init__()
+        self.preconf.optparser = self.__parser
+        self.preconf.plugin_types = (TYPE_CORE, TYPE_INTERACTIVE)
+        self.conf.assumeyes = True
+
+    def doPluginSetup(self, *args, **kwargs):
+        """
+        Plugin setup.
+
+        Args:
+            *args:
+            **kwargs:
+        """
+        super(LibYum, self).doPluginSetup(*args, **kwargs)
+        p = self.__parser
+        options, args = p.parse_args([])
+        self.plugins.setCmdLine(options, args)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *unused):
+        self.close()

--- a/src/katello/agent/pulp/report.py
+++ b/src/katello/agent/pulp/report.py
@@ -1,0 +1,182 @@
+import sys
+import traceback as tb
+
+
+class Report(object):
+    """
+    The base report.
+
+    Attributes:
+        succeeded (bool): Indicates whether or not a handler operation succeeded.
+        details (dict): Operation result details.
+        num_changes (int): The number of changes made during the operation.
+        The granularity is up to the discretion of the handler.
+    """
+
+    def __init__(self):
+        self.succeeded = True
+        self.details = {}
+        self.num_changes = 0
+
+    def dict(self):
+        """
+        Dictionary representation of the report.
+
+        Returns:
+            dict: Self.
+        """
+        return self.__dict__
+
+    def __str__(self):
+        return str(self.dict())
+
+    def __len__(self):
+        return self.num_changes
+
+
+class HandlerReport(Report):
+    """
+    The base handler report.
+
+    Attributes:
+        aggregation_key (str): The key used to aggregate details when
+            updating another report.
+    """
+
+    @staticmethod
+    def last_exception():
+        """
+        Get details of the last raised exception.
+
+        Returns:
+            dict: Details of last raised exception.
+        """
+        details = {}
+        info = sys.exc_info()
+        inst = info[1]
+        trace = '\n'.join(tb.format_exception(*info))
+        details['message'] = str(inst)
+        details['trace'] = trace
+        return details
+
+    def __init__(self):
+        Report.__init__(self)
+        self.aggregation_key = None
+
+    def set_succeeded(self, details=None, num_changes=0):
+        """
+        Called to indicate an operation succeeded.
+
+        Args:
+            details (dict): The details of the operation result.
+            num_changes (int): The number of changes made during the operation.
+                The granularity is up to the discretion of the handler.
+        """
+        self.succeeded = True
+        self.details = (details or {})
+        self.num_changes = num_changes
+
+    def set_failed(self, details=None):
+        """
+        Called to indicate an operation failed.
+
+        Args:
+            details (dict): The details of the operation result.
+        """
+        self.succeeded = False
+        self.details = (details or {})
+
+    def update(self, report):
+        """
+        Update the specified report.
+
+        Args:
+            report (DispatchReport): A dispatch report.
+        """
+        self._update_succeeded(report)
+        self._update_num_changes(report)
+        self._update_details(report)
+
+    def _update_succeeded(self, report):
+        """
+        Update the succeeded flag in the specified report.
+
+        Args:
+            report (DispatchReport): A dispatch report.
+        """
+        if not self.succeeded:
+            report.succeeded = self.succeeded
+
+    def _update_num_changes(self, report):
+        """
+        Update the num_changes in the specified report.
+
+        Args:
+            report (DispatchReport): A dispatch report.
+        """
+        if self.succeeded:
+            report.num_changes += self.num_changes
+
+    def _update_details(self, report):
+        """
+        Update the details in the specified report.
+        The details are aggregated in the specified report using
+        the aggregation key.
+
+        Args:
+            report (DispatchReport): A dispatch report.
+        """
+        report.details[self.aggregation_key] = dict(
+            succeeded=self.succeeded,
+            details=self.details)
+
+
+class ContentReport(HandlerReport):
+    """
+    The content report is returned by handler methods
+    implementing content unit operations.
+    """
+    pass
+
+
+class DispatchReport(Report):
+    """
+    The (internal) dispatch report is returned for all handler methods
+    dispatched to handlers.  It represents an aggregation of handler reports.
+    The handler (class) reports are collated by type_id (content, distributor, system).
+    The overall succeeded is True (succeeded) only if all of the handler reports have
+    a succeeded of True (succeeded).
+    Succeeded Example:
+      { 'succeeded' : True,
+        'num_changes' : 10,
+        'reboot' : { 'scheduled' : False, details : {} },
+        'details' : {
+          'type_A' : { 'succeeded' : True, 'details' : {} },
+          'type_B' : { 'succeeded' : True, 'details' : {} },
+          'type_C' : { 'succeeded' : True, 'details' : {} },
+        }
+      }
+    Failed Example:
+      { 'succeeded' : False,
+        'num_changes' : 6,
+        'reboot' : { 'scheduled' : False, details : {} },
+        'details' : {
+          'type_A' : { 'succeeded' : True, 'details' : {} },
+          'type_B' : { 'succeeded' : True, 'details' : {} },
+          'type_C' : { 'succeeded' : False,
+                       'details' : { 'message' : <message>, 'trace'=<trace> } },
+        }
+      }
+
+    Attributes:
+        succeeded (bool): The overall succeeded (succeeded|failed).
+        details (dict): operation details keyed by aggregation_key.
+            Each value is:
+                { 'succeeded' : True, details : {} }
+        num_changes (int): The number of changes made during the operation.
+            The granularity is up to the discretion of the handlers.
+    """
+
+    def __init__(self):
+        Report.__init__(self)
+        self.reboot = dict(scheduled=False, details={})

--- a/src/katello/agent/pulp/test.py
+++ b/src/katello/agent/pulp/test.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import
+
+
+from katello.agent.pulp.libdnf import *
+
+
+def test():
+    from dnf.cli.main import main as cli
+    cli(['install', 'ksh'])
+
+
+def test_pattern():
+    p = Pattern(name='jeff', version='1', arch='x68', release='2')
+    print(p)
+
+
+def test_packages(*pattern):
+    names = pattern or ['bmake', 'mk-files']
+    print('\n\nBegin')
+    package = Package()
+    log.info('\nInstalled [%s]: %s', names, package.install(names))
+    names = [n.split('-', 1)[0] for n in names]
+    log.info('\n\nUpdated [%s]: %s', names, package.update(names))
+    log.info('\n\nUninstall [%s]: %s', names, package.uninstall(names))
+    print('\nEnd')
+
+
+def test_packages2(*pattern):
+    print('\n\nBegin')
+    package = Package()
+    log.info('\nInstalled %s:\n%s', [str(p) for p in pattern], package.install(pattern))
+    for p in pattern:
+        p.version = ''
+        p.release = ''
+    log.info('\n\nUpdated %s:\n%s', [str(p) for p in pattern], package.update(pattern))
+    log.info('\n\nUninstall %s: \n%s', [str(p) for p in pattern], package.uninstall(pattern))
+    print('\nEnd')
+
+
+def test_groups():
+    names = ['Pulp Consumer']
+    print('\nBegin')
+    g = PackageGroup()
+    log.info('Installed (group) %s', g.install(names))
+    log.info('Uninstall (group) %s', g.uninstall(names))
+    print('\nEnd')
+
+
+def test_advisories():
+    with LibDnf() as dnf:
+        advisories = dnf.list_advisories()
+        for ad in advisories:
+            print('Ad: {}'.format(ad.id))
+            for p in ad.packages:
+                print('\t{}'.format(p.name))
+        print('total: {}'.format(len(advisories)))
+
+
+def test_applicable_advisories():
+    with LibDnf() as dnf:
+        advisories = dnf.applicable_advisories()
+        for ad, packages in advisories:
+            print('Ad: {}'.format(ad.id))
+            for p in sorted(packages):
+                print('\t{}'.format(p))
+        print('total: {}'.format(len(advisories)))
+
+
+def test_advisory_update():
+    print('\nBegin')
+    p = Package()
+    log.info('Ad-Update: %s', p.update(advisories=['FEDORA-2017-de8a421dcd']))
+    print('\nEnd')
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    test_pattern()
+    # test_packages()
+    test_packages2(
+        Pattern(name='walrus', version='0.71', release='1'),
+        Pattern(name='zsh')
+    )
+    # test_applicable_advisories()
+    # test_pattern()
+    # test_advisories()
+    # test_advisory_update()

--- a/src/setup.py
+++ b/src/setup.py
@@ -15,14 +15,7 @@
 # Jeff Ortel <jortel@redhat.com>
 #
 
-from platform import python_version
 from setuptools import setup, find_packages
-
-
-major, minor, micro = python_version().split('.')
-
-if major != '2' or minor not in ['4', '5', '6', '7']:
-    raise Exception('unsupported version of python')
 
 requires = [
 ]
@@ -36,8 +29,7 @@ setup(
     url='',
     license='GPLv2+',
     packages=find_packages(),
-    scripts = [
-    ],
+    scripts=[],
     include_package_data=False,
     data_files=[],
     classifiers=[

--- a/test/test_katello/test_plugin.py
+++ b/test/test_katello/test_plugin.py
@@ -41,7 +41,7 @@ class PluginTest(unittest.TestCase):
 
     @staticmethod
     def load_plugin():
-        plugin = __import__('katelloplugin', {}, {}, ['katelloplugin'])
+        plugin = __import__('katello.agent.goferd.plugin', {}, {}, ['katello.agent.goferd.plugin'])
         reload(plugin)
         plugin._module = plugin
         plugin_cfg = Mock()
@@ -81,8 +81,8 @@ class TestBundle(PluginTest):
 
 class TestCertificateChanged(PluginTest):
 
-    @patch('katello.agent.katelloplugin.update_settings')
-    @patch('katello.agent.katelloplugin.validate_registration')
+    @patch('katello.agent.goferd.plugin.update_settings')
+    @patch('katello.agent.goferd.plugin.validate_registration')
     def test_registered(self, validate, update_settings):
 
         # test
@@ -93,8 +93,8 @@ class TestCertificateChanged(PluginTest):
         update_settings.assert_called_with()
         self.plugin.plugin.attach.assert_called_with()
 
-    @patch('katello.agent.katelloplugin.update_settings')
-    @patch('katello.agent.katelloplugin.validate_registration')
+    @patch('katello.agent.goferd.plugin.update_settings')
+    @patch('katello.agent.goferd.plugin.validate_registration')
     def test_run_not_registered(self, validate, update_settings):
         self.plugin.registered = False
 
@@ -106,9 +106,9 @@ class TestCertificateChanged(PluginTest):
         self.assertFalse(update_settings.called)
         self.plugin.plugin.detach.assert_called_with()
 
-    @patch('katello.agent.katelloplugin.sleep')
-    @patch('katello.agent.katelloplugin.update_settings')
-    @patch('katello.agent.katelloplugin.validate_registration')
+    @patch('katello.agent.goferd.plugin.sleep')
+    @patch('katello.agent.goferd.plugin.update_settings')
+    @patch('katello.agent.goferd.plugin.validate_registration')
     def test_run_validate_failed(self, validate, update_settings, sleep):
         validate.side_effect = [ValueError, None]
 
@@ -125,9 +125,9 @@ class TestUpdateSettings(PluginTest):
     host = 'redhat.com'
     server_ca_cert = '%(ca_cert_dir)skatello-server-ca.pem'
 
-    @patch('katello.agent.katelloplugin.bundle')
-    @patch('katello.agent.katelloplugin.Config')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.plugin.bundle')
+    @patch('katello.agent.goferd.plugin.Config')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.read')
     def test_call_new(self, fake_read, fake_conf, fake_bundle):
         fake_conf.return_value = {
             'server': {
@@ -140,9 +140,9 @@ class TestUpdateSettings(PluginTest):
         }
         self.call(fake_read, fake_conf, fake_bundle)
 
-    @patch('katello.agent.katelloplugin.bundle')
-    @patch('katello.agent.katelloplugin.Config')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.plugin.bundle')
+    @patch('katello.agent.goferd.plugin.Config')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.read')
     def test_call_old_config(self, fake_read, fake_conf, fake_bundle):
         fake_conf.return_value = {
             'server': {
@@ -185,9 +185,9 @@ class TestUpdateSettings(PluginTest):
 
 class TestInitializer(PluginTest):
 
-    @patch('katello.agent.katelloplugin.path_monitor')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.certpath')
-    @patch('katello.agent.katelloplugin.validate_registration')
+    @patch('katello.agent.goferd.plugin.path_monitor')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.certpath')
+    @patch('katello.agent.goferd.plugin.validate_registration')
     def test_init(self, fake_validate, fake_path, fake_pmon):
         self.plugin.registered = False
 
@@ -200,8 +200,8 @@ class TestInitializer(PluginTest):
         fake_pmon.start.assert_called_with()
         fake_validate.assert_called_with()
 
-    @patch('katello.agent.katelloplugin.update_settings')
-    @patch('katello.agent.katelloplugin.validate_registration')
+    @patch('katello.agent.goferd.plugin.update_settings')
+    @patch('katello.agent.goferd.plugin.validate_registration')
     def test_registered(self, validate, update_settings):
 
         # test
@@ -212,8 +212,8 @@ class TestInitializer(PluginTest):
         update_settings.assert_called_with()
         self.assertFalse(self.plugin.plugin.attach.called)
 
-    @patch('katello.agent.katelloplugin.update_settings')
-    @patch('katello.agent.katelloplugin.validate_registration')
+    @patch('katello.agent.goferd.plugin.update_settings')
+    @patch('katello.agent.goferd.plugin.validate_registration')
     def test_run_not_registered(self, validate, update_settings):
         self.plugin.registered = False
 
@@ -225,9 +225,9 @@ class TestInitializer(PluginTest):
         self.assertFalse(update_settings.called)
         self.assertFalse(self.plugin.plugin.attach.called)
 
-    @patch('katello.agent.katelloplugin.sleep')
-    @patch('katello.agent.katelloplugin.update_settings')
-    @patch('katello.agent.katelloplugin.validate_registration')
+    @patch('katello.agent.goferd.plugin.sleep')
+    @patch('katello.agent.goferd.plugin.update_settings')
+    @patch('katello.agent.goferd.plugin.validate_registration')
     def test_run_validate_failed(self, validate, update_settings, sleep):
         validate.side_effect = [ValueError, None]
 
@@ -241,70 +241,11 @@ class TestInitializer(PluginTest):
         self.assertFalse(self.plugin.plugin.attach.called)
 
 
-class TestConduit(PluginTest):
-
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.read')
-    def test_consumer_id(self, fake_read):
-        consumer_id = '1234'
-        fake_certificate = Mock()
-        fake_certificate.getConsumerId.return_value = consumer_id
-        fake_read.return_value = fake_certificate
-
-        # test
-        conduit = self.plugin.Conduit()
-
-        # validation
-        self.assertEqual(conduit.consumer_id, consumer_id)
-
-    @patch('gofer.agent.rmi.Context.current')
-    def test_update_progress(self, mock_current):
-        mock_context = Mock()
-        mock_context.progress = Mock()
-        mock_current.return_value = mock_context
-        conduit = self.plugin.Conduit()
-        report = {'a': 1}
-
-        # test
-        conduit.update_progress(report)
-
-        # validation
-        # Reporting disabled
-        self.assertFalse(mock_context.progress.report.called)
-
-    @patch('gofer.agent.rmi.Context.current')
-    def test_cancelled(self, mock_current):
-        mock_context = Mock()
-        mock_context.cancelled = Mock(return_value=True)
-        mock_current.return_value = mock_context
-        conduit = self.plugin.Conduit()
-
-        # test
-        cancelled = conduit.cancelled()
-
-        # validation
-        self.assertTrue(cancelled)
-        self.assertTrue(mock_context.cancelled.called)
-
-    @patch('gofer.agent.rmi.Context.current')
-    def test_cancelled(self, mock_current):
-        mock_context = Mock()
-        mock_context.cancelled = Mock(return_value=False)
-        mock_current.return_value = mock_context
-        conduit = self.plugin.Conduit()
-
-        # test
-        cancelled = conduit.cancelled()
-
-        # validation
-        self.assertFalse(cancelled)
-        self.assertTrue(mock_context.cancelled.called)
-
-
 class TestUEP(PluginTest):
 
-    @patch('katello.agent.katelloplugin.UEPConnection.__init__')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.certpath')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.keypath')
+    @patch('katello.agent.goferd.plugin.UEPConnection.__init__')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.certpath')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.keypath')
     def test_construction(self, fake_keypath, fake_certpath, fake_conn_init):
         key_path = '/tmp/keypath'
         cert_path = '/tmp/crtpath'
@@ -319,9 +260,9 @@ class TestUEP(PluginTest):
 
 class TestValidateRegistration(PluginTest):
 
-    @patch('katello.agent.katelloplugin.UEP.getConsumer')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.read')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.existsAndValid')
+    @patch('katello.agent.goferd.plugin.UEP.getConsumer')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.existsAndValid')
     def test_validate_registration(self, valid, read, get_consumer):
         consumer_id = '1234'
         valid.return_value = True
@@ -334,8 +275,8 @@ class TestValidateRegistration(PluginTest):
         get_consumer.assert_called_with(consumer_id)
         self.assertTrue(self.plugin.registered)
 
-    @patch('katello.agent.katelloplugin.UEP.getConsumer')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.existsAndValid')
+    @patch('katello.agent.goferd.plugin.UEP.getConsumer')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.existsAndValid')
     def test_validate_registration_no_certificate(self, valid, get_consumer):
         valid.return_value = False
 
@@ -346,9 +287,9 @@ class TestValidateRegistration(PluginTest):
         self.assertFalse(get_consumer.called)
         self.assertFalse(self.plugin.registered)
 
-    @patch('katello.agent.katelloplugin.UEP.getConsumer')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.read')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.existsAndValid')
+    @patch('katello.agent.goferd.plugin.UEP.getConsumer')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.existsAndValid')
     def test_validate_registration_not_confirmed(self, valid, read, get_consumer):
         consumer_id = '1234'
         valid.return_value = True
@@ -362,9 +303,9 @@ class TestValidateRegistration(PluginTest):
         get_consumer.assert_called_with(consumer_id)
         self.assertFalse(self.plugin.registered)
 
-    @patch('katello.agent.katelloplugin.UEP.getConsumer')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.read')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.existsAndValid')
+    @patch('katello.agent.goferd.plugin.UEP.getConsumer')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.existsAndValid')
     def test_validate_registration_failed(self, valid, read, get_consumer):
         consumer_id = '1234'
         valid.return_value = True
@@ -378,9 +319,9 @@ class TestValidateRegistration(PluginTest):
         get_consumer.assert_called_with(consumer_id)
         self.assertFalse(self.plugin.registered)
 
-    @patch('katello.agent.katelloplugin.UEP.getConsumer')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.read')
-    @patch('katello.agent.katelloplugin.ConsumerIdentity.existsAndValid')
+    @patch('katello.agent.goferd.plugin.UEP.getConsumer')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.plugin.ConsumerIdentity.existsAndValid')
     def test_validate_registration_exception(self, valid, read, get_consumer):
         consumer_id = '1234'
         valid.return_value = True
@@ -402,9 +343,8 @@ class TestConsumer(PluginTest):
 
 class TestContent(PluginTest):
 
-    @patch('katello.agent.katelloplugin.Conduit')
-    @patch('katello.agent.katelloplugin.Dispatcher')
-    def test_install(self, mock_dispatcher, mock_conduit):
+    @patch('katello.agent.goferd.plugin.Dispatcher')
+    def test_install(self, mock_dispatcher):
         _report = Mock()
         _report.dict = Mock(return_value={'report': 883938})
         mock_dispatcher().install.return_value = _report
@@ -416,12 +356,11 @@ class TestContent(PluginTest):
         report = content.install(units, options)
 
         # validation
-        mock_dispatcher().install.assert_called_with(mock_conduit(), units, options)
+        mock_dispatcher().install.assert_called_with(units, options)
         self.assertEqual(report, _report.dict())
 
-    @patch('katello.agent.katelloplugin.Conduit')
-    @patch('katello.agent.katelloplugin.Dispatcher')
-    def test_update(self, mock_dispatcher, mock_conduit):
+    @patch('katello.agent.goferd.plugin.Dispatcher')
+    def test_update(self, mock_dispatcher):
         _report = Mock()
         _report.dict = Mock(return_value={'report': 883938})
         mock_dispatcher().update.return_value = _report
@@ -433,12 +372,11 @@ class TestContent(PluginTest):
         report = content.update(units, options)
 
         # validation
-        mock_dispatcher().update.assert_called_with(mock_conduit(), units, options)
+        mock_dispatcher().update.assert_called_with(units, options)
         self.assertEqual(report, _report.dict())
 
-    @patch('katello.agent.katelloplugin.Conduit')
-    @patch('katello.agent.katelloplugin.Dispatcher')
-    def test_uninstall(self, mock_dispatcher, mock_conduit):
+    @patch('katello.agent.goferd.plugin.Dispatcher')
+    def test_uninstall(self, mock_dispatcher):
         _report = Mock()
         _report.dict = Mock(return_value={'report': 883938})
         mock_dispatcher().uninstall.return_value = _report
@@ -450,7 +388,7 @@ class TestContent(PluginTest):
         report = content.uninstall(units, options)
 
         # validation
-        mock_dispatcher().uninstall.assert_called_with(mock_conduit(), units, options)
+        mock_dispatcher().uninstall.assert_called_with(units, options)
         self.assertEqual(report, _report.dict())
 
 
@@ -484,7 +422,7 @@ class TestAgentRestart(PluginTest):
         self.assertFalse(busy)
 
     @patch('os.unlink')
-    @patch('katello.agent.katelloplugin.Popen')
+    @patch('katello.agent.goferd.plugin.Popen')
     def test_restart(self, popen, unlink):
         popen.return_value.wait.return_value = 123
 


### PR DESCRIPTION
http://projects.theforeman.org/issues/21904

Initial PR: https://github.com/Katello/katello-host-tools/pull/55

Summary:
- Add (stripped down) pulp agent handler framework.  This is needed to provide integration between pulp and the agent.
- Add the DNF library[1] (wrapper). _New_.
- Add the YUM library[1] (wrapper).
- Add the RPM and errata handlers[1]. 
- Changes to katelloagent (plugin):
  - Installed (and loaded from) site-packages.
  - The Conduit removed.  This provided support for progress reporting and cancellation.  Neither used by katello.
  - Use the forking dispatch model.  This causes goferd to dispatch each RMI call to the plugin in a new child process.  This is needed because although the dnf lib is being initialized and closed correctly, bad things happen when using the lib twice in the same process.  This also ensure that dnf (and yum) memory (and file descriptor) leaks cannot impact goferd (daemon). 
- I took the liberty of organizing things into python packages.  The `katello.agent.goferd` packages contains the `plugin`.   The `katello.agent.pulp` package provides Pulp integration.

**[1]** Taken from pulp, stripped down, refactored a bit and ported to python 2.7/3.x.

Flows and abstraction layers:
```
Pulp (request) => goferd => katello <plugin> => Dispatcher => Handler => LibAPI => (DNF|YUM)
            <================ DispatchReport <= HandlerReport <= TransactionReport
```
---
*** THIS IS A WORK IN PROGRESS  ***

- Needs to be tested running in goferd.
- Needs to be tested w/ python3.
- The dnf support needs to log packages installed/updated/removed.
---
To run on python3, this will need gofer 2.12+.

The python3 compatible version (likely 2.12) is not packaged yet so for testing, it will need to be installed from source.

Deps:
- pam
- python3-six
- python3-future
- python3-qpid-proton

Steps:
```
# mkdir git
# git clone https://github.com/jortel/gofer.git
# git checkout python3-compat
# pushd gofer/src
# python3 setup.py install --no-compile --install-purelib /usr/lib/python3.6/site-packages
# popd
# mkdir -p /etc/gofer/plugins
# cp etc/gofer/agent.conf /etc/gofer
# cp docs/man/man1/goferd.1 /usr/share/man/man1
# vi bin/goferd

- #! /usr/bin/env python
+ #! /usr/bin/env python3

```
Running.  See: `man goferd`.
```
# bin/goferd 
# ps -ef |grep goferd
root      4292     1  0 15:16 ?        00:00:00 python bin/goferd
```
---

The plugin:
```
# cd git
# git clone https://github.com/jortel/katello-host-tools.git
# git checkout pulp-handler
# pushd src
# python3 setup.py install --no-compile --install-purelib /usr/lib/python3.6/site-packages
# popd
# cp etc/gofer/plugins/katello.conf /etc/gofer/plugins/
```

Restart goferd.
# 
