### PR TITLE
Fixes #23405 - Tracer executable throws error

### DIFF
--- a/bin/katello-tracer-upload
+++ b/bin/katello-tracer-upload
@@ -1,13 +1,11 @@
 #!/usr/bin/python
 
-import sys
-sys.path.append('/usr/lib/yum-plugins')
-
-import tracer_upload
+from katello import tracer
 
 
 def main():
-    tracer_upload.upload_tracer_profile()
+    tracer.upload_tracer_profile(tracer.query_affected_apps, None)
+
 
 if __name__ == "__main__":
     main()

--- a/src/katello/tracer.py
+++ b/src/katello/tracer.py
@@ -1,12 +1,29 @@
+from __future__ import absolute_import
+
+import sys
+
 from katello.uep import get_uep, lookup_consumer_id
+
+try:
+    from tracer.query import Query
+except ImportError:
+    sys.exit('Error Importing tracer! Is tracer installed?')
 
 
 def upload_tracer_profile(queryfunc, plugin):
     uep = get_uep()
+    consumer_id = lookup_consumer_id()
+    if consumer_id is None:
+        sys.stderr.write("Cannot upload tracer data, is this client registered?\n")
+    else:
+        method = '/consumers/%s/tracer' % uep.sanitize(consumer_id)
+        data = {"traces": get_apps(queryfunc, plugin)}
+        uep.conn.request_put(method, data)
 
-    method = '/consumers/%s/tracer' % uep.sanitize(lookup_consumer_id())
-    data = {"traces": get_apps(queryfunc, plugin)}
-    uep.conn.request_put(method, data)
+
+def query_affected_apps(plugin=None):
+    query = Query()
+    return query.affected_applications().get()
 
 
 def get_apps(queryfunc, plugin):

--- a/src/yum-plugins/tracer_upload.py
+++ b/src/yum-plugins/tracer_upload.py
@@ -1,36 +1,31 @@
-import sys
 import time
 
-try:
-  from tracer.query import Query
-except ImportError:
-  sys.exit('Error Importing tracer! Is tracer installed?')
+from katello.tracer import Query, upload_tracer_profile
 
-from yum.plugins import PluginYumExit, TYPE_CORE, TYPE_INTERACTIVE
-from katello.tracer import upload_tracer_profile
+from yum.plugins import TYPE_CORE, TYPE_INTERACTIVE
 
 requires_api_version = '2.3'
 plugin_type = (TYPE_CORE, TYPE_INTERACTIVE)
 
+
 def query_apps(conduit):
     """Returns all apps that need restarting """
     query = Query()
-    if conduit:
-        # When running via yum we need to pass tracer a list of packages and 
-        # their last modified time so it has no need to access the rpmdb (which
-        # would fail as yum/dnf has a lock on it) 
-        packages = []
-        pkgs = conduit.getTsInfo().getMembers() # Packages in the current transation
-        for pkg in pkgs:
-            pkg.modified = time.time()
-            packages.append(pkg)
-        rpmdb = conduit.getRpmDB() # All other packages
-        for pkg in rpmdb:
-            pkg.modified = pkg.installtime
-            packages.append(pkg)
-        return query.from_packages(packages).now().affected_applications().get()
-    else:
-        return query.affected_applications().get()
+
+    # When running via yum we need to pass tracer a list of packages and
+    # their last modified time so it has no need to access the rpmdb (which
+    # would fail as yum/dnf has a lock on it)
+    packages = []
+    pkgs = conduit.getTsInfo().getMembers()  # Packages in the current transation
+    for pkg in pkgs:
+        pkg.modified = time.time()
+        packages.append(pkg)
+    rpmdb = conduit.getRpmDB()  # All other packages
+    for pkg in rpmdb:
+        pkg.modified = pkg.installtime
+        packages.append(pkg)
+    return query.from_packages(packages).now().affected_applications().get()
+
 
 def posttrans_hook(conduit):
     if not conduit.confBool("main", "supress_debug"):


### PR DESCRIPTION
The ./bin/katello-tracer-upload script wasn't updated in all the recent refactoring in this repo, and so the traceback in the issue was shown with no tracer info uploaded to Katello

### To reproduce

Spin up a centos7 box and register it to some katello instance

```
vagrant up centos7
```

Checkout the master branch, and build the code:
```
cd src/
python setup.py install
```

Run the tracer script:
```
python -- ./bin/katello-tracer-upload
```

You should see 

```
Traceback (most recent call last):
File "bin/katello-tracer-upload", line 13, in <module>
main()
File "bin/katello-tracer-upload", line 10, in main
tracer_upload.upload_tracer_profile()
TypeError: upload_tracer_profile() takes exactly 2 arguments (0 given)
```

### To verify the fix

Check out this PR, rebuild the code, and run the tracer-upload script again - it should succeed and you can verify by checking that Katello received a PUT to `Katello::Api::Rhsm::CandlepinProxiesController#upload_tracer_profile`

You may also want to verify the yum plugin side since that code was affected:

Install the yum plugin:

```
ln -s ~/git/katello-host-tools/src/yum-plugins/tracer_upload.py /usr/share/yum-plugins/tracer_upload.py
```

Perform some action via YUM, and you should once again see Katello receive a PUT for tracer