### PR TITLE
Fixes #23459 - Restore legacy goferd plugin

### DIFF
--- a/images/Dockerfile.el6
+++ b/images/Dockerfile.el6
@@ -1,8 +1,8 @@
 FROM centos:6
 
-COPY containers/assets/jortel-gofer-epel.repo /etc/yum.repos.d/jortel-gofer-epel.repo
 RUN yum install -y wget epel-release && yum clean all
+RUN yum install -y https://fedorapeople.org/groups/katello/releases/yum/3.4/client/el6/x86_64/katello-client-repos-latest.rpm && yum clean all
 RUN wget -O /etc/yum.repos.d/epel-subscriptions-manager.repo http://repos.fedorapeople.org/repos/candlepin/subscription-manager/epel-subscription-manager.repo
-RUN yum install make gofer subscription-manager python-pip -y && yum clean all
+RUN yum install make gofer python-pulp-agent-lib subscription-manager python-pip -y && yum clean all
 RUN pip install setuptools==36.7.0
 WORKDIR /app

--- a/src/katello/agent/goferd/legacy_plugin.py
+++ b/src/katello/agent/goferd/legacy_plugin.py
@@ -1,0 +1,369 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+"""
+The katello virtual agent.
+Provides content management APIs for pulp within the RHSM environment.
+"""
+
+import os
+import sys
+import httplib
+
+sys.path.append('/usr/share/rhsm')
+
+from time import sleep
+from logging import getLogger
+from subprocess import Popen
+
+from katello.constants import REPOSITORY_PATH
+from katello.repos import upload_enabled_repos_report
+from katello.enabled_report import EnabledReport
+
+from gofer.decorators import initializer, remote, action
+from gofer.agent.plugin import Plugin
+from gofer.pmon import PathMonitor
+from gofer.agent.rmi import Context
+from gofer.config import Config
+
+
+try:
+    from subscription_manager.identity import ConsumerIdentity
+except ImportError:
+    from subscription_manager.certlib import ConsumerIdentity
+
+from rhsm.connection import UEPConnection, RemoteServerException
+
+from pulp.agent.lib.dispatcher import Dispatcher
+from pulp.agent.lib.conduit import Conduit as HandlerConduit
+
+
+# This plugin
+plugin = Plugin.find(__name__)
+
+# Path monitoring
+path_monitor = PathMonitor()
+
+# Track registration status
+registered = False
+
+
+log = getLogger(__name__)
+
+
+RHSM_CONFIG_PATH = '/etc/rhsm/rhsm.conf'
+
+
+@initializer
+def init_plugin():
+    """
+    Initialize the plugin.
+    Called (once) immediately after the plugin is loaded.
+     - setup path monitoring.
+     - validate registration.  If registered:
+       - setup plugin configuration.
+    """
+    path = ConsumerIdentity.certpath()
+    path_monitor.add(path, certificate_changed)
+    path_monitor.add(REPOSITORY_PATH, send_enabled_report)
+    path_monitor.start()
+    while True:
+        try:
+            validate_registration()
+            if registered:
+                update_settings()
+            # DONE
+            break
+        except Exception, e:
+            log.warn(str(e))
+            sleep(60)
+
+
+def bundle(certificate):
+    """
+    Bundle the key and cert and write to a file.
+    :param certificate: A consumer identity certificate.
+    :type certificate: ConsumerIdentity
+    :return: The path to written bundle.
+    :rtype: str
+    """
+    path = os.path.join(certificate.PATH, 'bundle.pem')
+    fp = open(path, 'w')
+    try:
+        fp.write(certificate.key)
+        fp.write(certificate.cert)
+        return path
+    finally:
+        fp.close()
+
+
+def certificate_changed(path):
+    """
+    A certificate change has been detected.
+    On registration: setup the plugin; attach to the message broker.
+    On un-registration: detach from the message broker.
+    :param path: The path to the file that changed.
+    :type path: str
+    """
+    log.info('changed: %s', path)
+    while True:
+        try:
+            validate_registration()
+            if registered:
+                update_settings()
+                send_enabled_report()
+                plugin.attach()
+            else:
+                plugin.detach()
+            # DONE
+            break
+        except Exception, e:
+            log.warn(str(e))
+            sleep(60)
+
+def send_enabled_report(path=REPOSITORY_PATH):
+    report = EnabledReport(path)
+    upload_enabled_repos_report(report)
+
+def update_settings():
+    """
+    Setup the plugin based on the RHSM configuration.
+    """
+    rhsm_conf = Config(RHSM_CONFIG_PATH)
+    certificate = ConsumerIdentity.read()
+    if rhsm_conf['rhsm'].has_key('ca_cert_dir'):
+        ca_cert_dir = rhsm_conf['rhsm']['ca_cert_dir']
+    else:
+        #handle old subscription-manager configurations
+        ca_cert_dir = rhsm_conf['server']['ca_cert_dir']
+ 
+    # the 'katello-default-ca.pem' is the ca used for generating the CA certs.
+    # the 'candlepin-local.pem' is there for compatibility reasons (the old path where the
+    # legacy installer was putting this file. If none of them is present, there is still
+    # a chance the rhsm_conf['rhsm']['repo_ca_cert'] is serving as the CA for issuing
+    # the client certs
+    ca_candidates = [os.path.join(ca_cert_dir, 'katello-default-ca.pem'),
+                     os.path.join(ca_cert_dir, 'candlepin-local.pem'),
+                     rhsm_conf['rhsm']['repo_ca_cert'] % {'ca_cert_dir': ca_cert_dir}]
+    existing_ca_certs = [cert for cert in ca_candidates if os.path.exists(cert)]
+    if not existing_ca_certs:
+       log.warn('None of the ca cert files %s found for the qpid connection' % ca_candidates)
+
+       raise
+    else:
+       log.info('Using %s as the ca cert for qpid connection' % existing_ca_certs[0])
+
+    plugin.cfg.messaging.cacert = existing_ca_certs[0]
+    plugin.cfg.messaging.url = 'proton+amqps://%s:5647' % rhsm_conf['server']['hostname']
+    plugin.cfg.messaging.uuid = 'pulp.agent.%s' % certificate.getConsumerId()
+    bundle(certificate)
+
+
+def validate_registration():
+    """
+    Validate consumer registration by making a REST call
+    to the server.  Updates the global 'registered' variable.
+    """
+    global registered
+    registered = False
+
+    if ConsumerIdentity.existsAndValid():
+        consumer = ConsumerIdentity.read()
+        consumer_id = consumer.getConsumerId()
+    else:
+        return
+
+    try:
+        uep = UEP()
+        consumer = uep.getConsumer(consumer_id)
+        registered = (consumer is not None)
+    except RemoteServerException, e:
+        if e.code != httplib.NOT_FOUND:
+            log.warn(str(e))
+            raise
+    except Exception, e:
+        log.exception(str(e))
+        raise
+
+
+class AgentRestart(object):
+    """
+    Restart the daemon after RPM upgrade.
+    The %post in the RPM will write the RESTART_FILE.  The recurring
+    'apply' action notices file and restarts the goferd service only when
+    this plugin is not longer busy.
+    """
+
+    COMMAND = 'service goferd restart'
+    RESTART_FILE = '/tmp/katello-agent-restart'
+
+    @staticmethod
+    def is_busy():
+        """
+        Determine if this plugin is busy by counting the pending
+        requests in the persistent queue.
+
+        :return: True if busy.
+        :rtype: bool
+        """
+        pending = plugin.scheduler.pending
+        path = os.path.join(pending.PENDING, pending.stream)
+        count = len(os.listdir(path))
+        return count > 0
+
+    @staticmethod
+    def restart():
+        """
+        Restart the goferd service.
+          1. Delete the RESTART_FILE.
+          2. Restart
+
+        :return: The restart command exit value.
+        :rtype: int
+        """
+        os.unlink(AgentRestart.RESTART_FILE)
+        p = Popen(AgentRestart.COMMAND, shell=True)
+        return p.wait()
+
+    @action(minutes=3)
+    def apply(self):
+        """
+        Detect the RESTART_FILE and restart the goferd service
+        only when this plugin is not longer busy.  This ensures that
+        an RPM update has completed.
+        """
+        if not os.path.exists(AgentRestart.RESTART_FILE):
+            return
+        if self.is_busy():
+            return
+        log.info('Restarting goferd.')
+        exit_val = self.restart()
+        # only reached when restart failed.
+        log.error('Restart failed, exit=%d', exit_val)
+
+
+class Conduit(HandlerConduit):
+    """
+    Provides integration between the gofer and pulp agent handler frameworks.
+    """
+
+    @property
+    def consumer_id(self):
+        """
+        Get the current consumer ID
+        :return: The unique consumer ID of the currently running agent
+        :rtype:  str
+        """
+        certificate = ConsumerIdentity.read()
+        return certificate.getConsumerId()
+
+    def update_progress(self, report):
+        """
+        This method inentionally left blank mitigate Qpid journal
+        latency related to AMQP 1.0.  The latency significantly
+        degrades performance. If a better solution is found we
+        may re-enable this method to actually report back progress.
+        See http://projects.theforeman.org/issues/12375
+        :param report: A handler progress report.
+        :type report: object
+        """
+
+    def cancelled(self):
+        """
+        Get whether the current operation has been cancelled.
+        :return: True if cancelled, else False.
+        :rtype: bool
+        """
+        context = Context.current()
+        return context.cancelled()
+
+class UEP(UEPConnection):
+    """
+    Represents the UEP.
+    """
+
+    def __init__(self):
+        key = ConsumerIdentity.keypath()
+        cert = ConsumerIdentity.certpath()
+        UEPConnection.__init__(self, key_file=key, cert_file=cert)
+
+
+# --- API --------------------------------------------------------------------
+class Consumer(object):
+    """
+    When a consumer is unregistered, Katello notifies the goferd.
+    """
+
+    @remote
+    def unregister(self):
+        log.info('Consumer has been unregistered. Katello agent will no longer function until this system is reregistered.')
+
+
+class Content(object):
+    """
+    Pulp Content Management.
+    """
+
+    @remote
+    def install(self, units, options):
+        """
+        Install the specified content units using the specified options.
+        Delegated to content handlers.
+        :param units: A list of content units to be installed.
+        :type units: list of:
+            { type_id:<str>, unit_key:<dict> }
+        :param options: Install options; based on unit type.
+        :type options: dict
+        :return: A dispatch report.
+        :rtype: DispatchReport
+        """
+        conduit = Conduit()
+        dispatcher = Dispatcher()
+        report = dispatcher.install(conduit, units, options)
+        return report.dict()
+
+    @remote
+    def update(self, units, options):
+        """
+        Update the specified content units using the specified options.
+        Delegated to content handlers.
+        :param units: A list of content units to be updated.
+        :type units: list of:
+            { type_id:<str>, unit_key:<dict> }
+        :param options: Update options; based on unit type.
+        :type options: dict
+        :return: A dispatch report.
+        :rtype: DispatchReport
+        """
+        conduit = Conduit()
+        dispatcher = Dispatcher()
+        report = dispatcher.update(conduit, units, options)
+        return report.dict()
+
+    @remote
+    def uninstall(self, units, options):
+        """
+        Uninstall the specified content units using the specified options.
+        Delegated to content handlers.
+        :param units: A list of content units to be uninstalled.
+        :type units: list of:
+            { type_id:<str>, unit_key:<dict> }
+        :param options: Uninstall options; based on unit type.
+        :type options: dict
+        :return: A dispatch report.
+        :rtype: DispatchReport
+        """
+        conduit = Conduit()
+        dispatcher = Dispatcher()
+        report = dispatcher.uninstall(conduit, units, options)
+        return report.dict()

--- a/test/test_katello/legacy_plugin_test.py
+++ b/test/test_katello/legacy_plugin_test.py
@@ -1,0 +1,528 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+import httplib
+import os
+import sys
+import unittest
+
+from mock import Mock, patch
+
+from rhsm.connection import RemoteServerException
+
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/yum-plugins'))
+
+
+class Repository(object):
+
+    def __init__(self, repo_id, repofile, baseurl):
+        self.id = repo_id
+        self.repofile = repofile
+        self.baseurl = baseurl
+
+
+class PluginTest(unittest.TestCase):
+
+    @staticmethod
+    def load_plugin():
+        plugin = __import__('katello.agent.goferd.legacy_plugin', {}, {}, ['katello.agent.goferd.legacy_plugin'])
+        reload(plugin)
+        plugin._module = plugin
+        plugin_cfg = Mock()
+        plugin_cfg.messaging = Mock()
+        plugin.plugin = Mock()
+        plugin.plugin.scheduler = Mock()
+        plugin.plugin.scheduler.pending = Mock(PENDING='/tmp/pending', stream='abc')
+        plugin.plugin.cfg = plugin_cfg
+        plugin.path_monitor = Mock()
+        plugin.registered = True
+        return plugin
+
+    def setUp(self):
+        self.plugin = PluginTest.load_plugin()
+
+
+class TestBundle(PluginTest):
+
+    @patch('__builtin__.open')
+    def test_bundle(self, fake_open):
+        fake_fp = Mock()
+        fake_open.return_value = fake_fp
+
+        # test
+        certificate = Mock()
+        certificate.PATH = '/tmp/path/test'
+        certificate.key = 'TEST-KEY'
+        certificate.cert = 'TEST-CERT'
+        self.plugin.bundle(certificate)
+
+        # validation
+        fake_open.assert_called_with(os.path.join(certificate.PATH, 'bundle.pem'), 'w')
+        fake_fp.write.assert_any_call(certificate.key)
+        fake_fp.write.assert_any_call(certificate.cert)
+        fake_fp.close.assert_called_with()
+
+
+class TestCertificateChanged(PluginTest):
+
+    @patch('katello.agent.goferd.legacy_plugin.update_settings')
+    @patch('katello.agent.goferd.legacy_plugin.validate_registration')
+    def test_registered(self, validate, update_settings):
+
+        # test
+        self.plugin.certificate_changed('')
+
+        # validation
+        validate.assert_called_with()
+        update_settings.assert_called_with()
+        self.plugin.plugin.attach.assert_called_with()
+
+    @patch('katello.agent.goferd.legacy_plugin.update_settings')
+    @patch('katello.agent.goferd.legacy_plugin.validate_registration')
+    def test_run_not_registered(self, validate, update_settings):
+        self.plugin.registered = False
+
+        # test
+        self.plugin.certificate_changed('')
+
+        # validation
+        validate.assert_called_with()
+        self.assertFalse(update_settings.called)
+        self.plugin.plugin.detach.assert_called_with()
+
+    @patch('katello.agent.goferd.legacy_plugin.sleep')
+    @patch('katello.agent.goferd.legacy_plugin.update_settings')
+    @patch('katello.agent.goferd.legacy_plugin.validate_registration')
+    def test_run_validate_failed(self, validate, update_settings, sleep):
+        validate.side_effect = [ValueError, None]
+
+        # test
+        self.plugin.certificate_changed('')
+
+        # validation
+        validate.assert_called_with()
+        sleep.assert_called_once_with(60)
+        update_settings.assert_called_with()
+        self.plugin.plugin.attach.assert_called_with()
+
+
+class TestUpdateSettings(PluginTest):
+    host = 'redhat.com'
+    server_ca_cert = '%(ca_cert_dir)skatello-server-ca.pem'
+
+    @patch('katello.agent.goferd.legacy_plugin.bundle')
+    @patch('katello.agent.goferd.legacy_plugin.Config')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.read')
+    def test_call_new(self, fake_read, fake_conf, fake_bundle):
+        fake_conf.return_value = {
+            'server': {
+                'hostname': self.host
+            },
+            'rhsm': {
+                'repo_ca_cert': self.server_ca_cert,
+                'ca_cert_dir': self.ca_cert_dir()
+            }
+        }
+        self.call(fake_read, fake_conf, fake_bundle)
+
+    @patch('katello.agent.goferd.legacy_plugin.bundle')
+    @patch('katello.agent.goferd.legacy_plugin.Config')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.read')
+    def test_call_old_config(self, fake_read, fake_conf, fake_bundle):
+        fake_conf.return_value = {
+            'server': {
+                'hostname': self.host,
+                'ca_cert_dir': self.ca_cert_dir()
+            },
+            'rhsm': {
+                'repo_ca_cert': self.server_ca_cert,
+            }
+        }
+        self.call(fake_read, fake_conf, fake_bundle)
+
+    def ca_cert_dir(self):
+        ca_cert_dir = os.path.join(os.path.dirname(__file__), 'data/ca/')
+        if not os.path.exists(ca_cert_dir):
+            os.makedirs(ca_cert_dir)
+        return ca_cert_dir
+
+    def call(self, fake_read, fake_conf, fake_bundle):
+        consumer_id = '1234'
+        default_ca_cert = os.path.join(self.ca_cert_dir(), 'katello-default-ca.pem')
+        if not os.path.exists(default_ca_cert):
+            open(default_ca_cert, 'a').close()
+
+        fake_certificate = Mock()
+        fake_certificate.getConsumerId.return_value = consumer_id
+        fake_read.return_value = fake_certificate
+
+        # test
+        self.plugin.update_settings()
+
+        # validation
+        fake_read.assert_called_with()
+        fake_bundle.assert_called_with(fake_certificate)
+        plugin_cfg = self.plugin.plugin.cfg
+        self.assertEqual(plugin_cfg.messaging.cacert, default_ca_cert)
+        self.assertEqual(plugin_cfg.messaging.url, 'proton+amqps://%s:5647' % self.host)
+        self.assertEqual(plugin_cfg.messaging.uuid, 'pulp.agent.%s' % consumer_id)
+
+
+class TestInitializer(PluginTest):
+
+    @patch('katello.agent.goferd.legacy_plugin.path_monitor')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.certpath')
+    @patch('katello.agent.goferd.legacy_plugin.validate_registration')
+    def test_init(self, fake_validate, fake_path, fake_pmon):
+        self.plugin.registered = False
+
+        # test
+        self.plugin.init_plugin()
+
+        # validation
+        fake_path.assert_called_with()
+        fake_pmon.add.assert_any_call(fake_path(), self.plugin.certificate_changed)
+        fake_pmon.start.assert_called_with()
+        fake_validate.assert_called_with()
+
+    @patch('katello.agent.goferd.legacy_plugin.update_settings')
+    @patch('katello.agent.goferd.legacy_plugin.validate_registration')
+    def test_registered(self, validate, update_settings):
+
+        # test
+        self.plugin.init_plugin()
+
+        # validation
+        validate.assert_called_with()
+        update_settings.assert_called_with()
+        self.assertFalse(self.plugin.plugin.attach.called)
+
+    @patch('katello.agent.goferd.legacy_plugin.update_settings')
+    @patch('katello.agent.goferd.legacy_plugin.validate_registration')
+    def test_run_not_registered(self, validate, update_settings):
+        self.plugin.registered = False
+
+        # test
+        self.plugin.init_plugin()
+
+        # validation
+        validate.assert_called_with()
+        self.assertFalse(update_settings.called)
+        self.assertFalse(self.plugin.plugin.attach.called)
+
+    @patch('katello.agent.goferd.legacy_plugin.sleep')
+    @patch('katello.agent.goferd.legacy_plugin.update_settings')
+    @patch('katello.agent.goferd.legacy_plugin.validate_registration')
+    def test_run_validate_failed(self, validate, update_settings, sleep):
+        validate.side_effect = [ValueError, None]
+
+        # test
+        self.plugin.init_plugin()
+
+        # validation
+        validate.assert_called_with()
+        sleep.assert_called_once_with(60)
+        update_settings.assert_called_with()
+        self.assertFalse(self.plugin.plugin.attach.called)
+
+
+class TestConduit(PluginTest):
+
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.read')
+    def test_consumer_id(self, fake_read):
+        consumer_id = '1234'
+        fake_certificate = Mock()
+        fake_certificate.getConsumerId.return_value = consumer_id
+        fake_read.return_value = fake_certificate
+
+        # test
+        conduit = self.plugin.Conduit()
+
+        # validation
+        self.assertEqual(conduit.consumer_id, consumer_id)
+
+    @patch('gofer.agent.rmi.Context.current')
+    def test_update_progress(self, mock_current):
+        mock_context = Mock()
+        mock_context.progress = Mock()
+        mock_current.return_value = mock_context
+        conduit = self.plugin.Conduit()
+        report = {'a': 1}
+
+        # test
+        conduit.update_progress(report)
+
+        # validation
+        # Reporting disabled
+        self.assertFalse(mock_context.progress.report.called)
+
+    @patch('gofer.agent.rmi.Context.current')
+    def test_cancelled(self, mock_current):
+        mock_context = Mock()
+        mock_context.cancelled = Mock(return_value=False)
+        mock_current.return_value = mock_context
+        conduit = self.plugin.Conduit()
+
+        # test
+        cancelled = conduit.cancelled()
+
+        # validation
+        self.assertFalse(cancelled)
+        self.assertTrue(mock_context.cancelled.called)
+
+
+class TestUEP(PluginTest):
+
+    @patch('katello.agent.goferd.legacy_plugin.UEPConnection.__init__')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.certpath')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.keypath')
+    def test_construction(self, fake_keypath, fake_certpath, fake_conn_init):
+        key_path = '/tmp/keypath'
+        cert_path = '/tmp/crtpath'
+        fake_keypath.return_value = key_path
+        fake_certpath.return_value = cert_path
+
+        # test
+        uep = self.plugin.UEP()
+
+        # validation
+        fake_conn_init.assert_called_with(uep, key_file=key_path, cert_file=cert_path)
+
+
+class TestValidateRegistration(PluginTest):
+
+    @patch('katello.agent.goferd.legacy_plugin.UEPConnection.getConsumer')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.existsAndValid')
+    def test_validate_registration(self, valid, read, get_consumer):
+        consumer_id = '1234'
+        valid.return_value = True
+        read.return_value.getConsumerId.return_value = consumer_id
+
+        # test
+        self.plugin.validate_registration()
+
+        # validation
+        get_consumer.assert_called_with(consumer_id)
+        self.assertTrue(self.plugin.registered)
+
+    @patch('katello.agent.goferd.legacy_plugin.UEPConnection.getConsumer')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.existsAndValid')
+    def test_validate_registration_no_certificate(self, valid, get_consumer):
+        valid.return_value = False
+
+        # test
+        self.plugin.validate_registration()
+
+        # validation
+        self.assertFalse(get_consumer.called)
+        self.assertFalse(self.plugin.registered)
+
+    @patch('katello.agent.goferd.legacy_plugin.UEPConnection.getConsumer')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.existsAndValid')
+    def test_validate_registration_not_confirmed(self, valid, read, get_consumer):
+        consumer_id = '1234'
+        valid.return_value = True
+        read.return_value.getConsumerId.return_value = consumer_id
+        get_consumer.side_effect = RemoteServerException(httplib.NOT_FOUND)
+
+        # test
+        self.plugin.validate_registration()
+
+        # validation
+        get_consumer.assert_called_with(consumer_id)
+        self.assertFalse(self.plugin.registered)
+
+    @patch('katello.agent.goferd.legacy_plugin.UEPConnection.getConsumer')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.existsAndValid')
+    def test_validate_registration_failed(self, valid, read, get_consumer):
+        consumer_id = '1234'
+        valid.return_value = True
+        read.return_value.getConsumerId.return_value = consumer_id
+        get_consumer.side_effect = RemoteServerException(httplib.BAD_REQUEST)
+
+        # test
+        self.assertRaises(RemoteServerException, self.plugin.validate_registration)
+
+        # validation
+        get_consumer.assert_called_with(consumer_id)
+        self.assertFalse(self.plugin.registered)
+
+    @patch('katello.agent.goferd.legacy_plugin.UEPConnection.getConsumer')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.read')
+    @patch('katello.agent.goferd.legacy_plugin.ConsumerIdentity.existsAndValid')
+    def test_validate_registration_exception(self, valid, read, get_consumer):
+        consumer_id = '1234'
+        valid.return_value = True
+        read.return_value.getConsumerId.return_value = consumer_id
+        get_consumer.side_effect = ValueError
+
+        # test
+        self.assertRaises(ValueError, self.plugin.validate_registration)
+
+        # validation
+        get_consumer.assert_called_with(consumer_id)
+        self.assertFalse(self.plugin.registered)
+
+
+class TestConsumer(PluginTest):
+
+    def test_unregister(self):
+        consumer = self.plugin.Consumer()
+        consumer.unregister()
+
+
+class TestContent(PluginTest):
+
+    @patch('katello.agent.goferd.legacy_plugin.Conduit')
+    @patch('katello.agent.goferd.legacy_plugin.Dispatcher')
+    def test_install(self, mock_dispatcher, mock_conduit):
+        _report = Mock()
+        _report.dict = Mock(return_value={'report': 883938})
+        mock_dispatcher().install.return_value = _report
+
+        # test
+        units = [{'A': 1}]
+        options = {'B': 2}
+        content = self.plugin.Content()
+        report = content.install(units, options)
+
+        # validation
+        mock_dispatcher().install.assert_called_with(mock_conduit(), units, options)
+        self.assertEqual(report, _report.dict())
+
+    @patch('katello.agent.goferd.legacy_plugin.Conduit')
+    @patch('katello.agent.goferd.legacy_plugin.Dispatcher')
+    def test_update(self, mock_dispatcher, mock_conduit):
+        _report = Mock()
+        _report.dict = Mock(return_value={'report': 883938})
+        mock_dispatcher().update.return_value = _report
+
+        # test
+        units = [{'A': 10}]
+        options = {'B': 20}
+        content = self.plugin.Content()
+        report = content.update(units, options)
+
+        # validation
+        mock_dispatcher().update.assert_called_with(mock_conduit(), units, options)
+        self.assertEqual(report, _report.dict())
+
+    @patch('katello.agent.goferd.legacy_plugin.Conduit')
+    @patch('katello.agent.goferd.legacy_plugin.Dispatcher')
+    def test_uninstall(self, mock_dispatcher, mock_conduit):
+        _report = Mock()
+        _report.dict = Mock(return_value={'report': 883938})
+        mock_dispatcher().uninstall.return_value = _report
+
+        # test
+        units = [{'A': 100}]
+        options = {'B': 200}
+        content = self.plugin.Content()
+        report = content.uninstall(units, options)
+
+        # validation
+        mock_dispatcher().uninstall.assert_called_with(mock_conduit(), units, options)
+        self.assertEqual(report, _report.dict())
+
+
+class TestAgentRestart(PluginTest):
+
+    @patch('os.listdir')
+    def test_busy(self, listdir):
+        listdir.return_value = [
+            'file0',
+            'file1'
+        ]
+
+        # test
+        restart = self.plugin.AgentRestart()
+        busy = restart.is_busy()
+
+        # validation
+        listdir.assert_called_once_with('/tmp/pending/abc')
+        self.assertTrue(busy)
+
+    @patch('os.listdir')
+    def test_not_busy(self, listdir):
+        listdir.return_value = []
+
+        # test
+        restart = self.plugin.AgentRestart()
+        busy = restart.is_busy()
+
+        # validation
+        listdir.assert_called_once_with('/tmp/pending/abc')
+        self.assertFalse(busy)
+
+    @patch('os.unlink')
+    @patch('katello.agent.goferd.legacy_plugin.Popen')
+    def test_restart(self, popen, unlink):
+        popen.return_value.wait.return_value = 123
+
+        # test
+        restart = self.plugin.AgentRestart()
+        exit_val = restart.restart()
+
+        # validation
+        unlink.assert_called_once_with(self.plugin.AgentRestart.RESTART_FILE)
+        popen.assert_called_once_with(self.plugin.AgentRestart.COMMAND, shell=True)
+        popen.return_value.wait.assert_called_once_with()
+        self.assertEqual(exit_val, popen.return_value.wait.return_value)
+
+    @patch('os.path.exists')
+    def test_apply_not_requested(self, exists):
+        exists.return_value = False
+
+        # test
+        restart = self.plugin.AgentRestart()
+        restart.restart = Mock()
+        restart.apply()
+
+        # validation
+        exists.assert_called_once_with(self.plugin.AgentRestart.RESTART_FILE)
+        self.assertFalse(restart.restart.called)
+
+    @patch('os.path.exists')
+    def test_apply_request_and_busy(self, exists):
+        exists.return_value = True
+
+        # test
+        restart = self.plugin.AgentRestart()
+        restart.is_busy = Mock(return_value=True)
+        restart.restart = Mock()
+        restart.apply()
+
+        # validation
+        exists.assert_called_once_with(self.plugin.AgentRestart.RESTART_FILE)
+        restart.is_busy.assert_called_once_with()
+        self.assertFalse(restart.restart.called)
+
+    @patch('os.path.exists')
+    def test_apply_restarted(self, exists):
+        exists.return_value = True
+
+        # test
+        restart = self.plugin.AgentRestart()
+        restart.is_busy = Mock(return_value=False)
+        restart.restart = Mock(return_value=0)
+        restart.apply()
+
+        # validation
+        exists.assert_called_once_with(self.plugin.AgentRestart.RESTART_FILE)
+        restart.is_busy.assert_called_once_with()
+        restart.restart.assert_called_once_with()

--- a/test/unittest_suite.py
+++ b/test/unittest_suite.py
@@ -13,6 +13,9 @@ if sys.version_info[0] == 2:
 
     if sys.version_info[1] > 6:
         modules.append('test_katello.test_plugin')
+    else:
+        # this test file doesn't start with test_ to avoid py3 unittest discovery
+        modules.append('test_katello.legacy_plugin_test')
 
     map(__import__, modules)
 


### PR DESCRIPTION
You may want to test an el5 and el6 client. These changes will require some adjustments to the specfile which I'll handle after this is merged.

Basically, this code is duplicated so that we are less concerned with breaking it on older clients and when it comes times to drop support we can delete these added files.

Steps:

1. Provision system
2.  set up some repos
```
wget -O /etc/yum.repos.d/epel-rhsm.repo http://repos.fedorapeople.org/repos/candlepin/subscription-manager/epel-subscription-manager.repo
yum install https://fedorapeople.org/groups/katello/releases/yum/3.5/client/el6/x86_64/katello-client-repos-latest.rpm
```
3. yum install subscription-manager gofer python-pulp-agent-lib python-gofer-proton pulp-rpm-handlers
4. register the system to your katello
5. checkout this PR
```
yum install git && git clone https://github.com/katello/katello-host-tools
git fetch origin pull/60/head:pr60 && git checkout pr60
```
6. Set up agent and host-tools:

```
# shared libs
ln -s /root/katello-host-tools/src/katello /usr/lib/python2.6/site-packages/katello

#goferd
sed -i 's/katello.agent.goferd.plugin/katello.agent.goferd.legacy_plugin/g' /root/katello-host-tools/etc/gofer/plugins/katello.conf
cp /root/katello-host-tools/etc/gofer/plugins/katello.conf  /etc/gofer/plugins/

service goferd start
```
- check /var/log/messages to ensure no errors were raised by gofer
- Perform some package actions against the host via katello - should work through the agent