### PR TITLE
Fix errata install - upgrating unrelated packages.

### DIFF
--- a/src/katello/agent/pulp/libdnf.py
+++ b/src/katello/agent/pulp/libdnf.py
@@ -239,8 +239,6 @@ class Package(API):
                 for ad, packages in lib.applicable_advisories(AdvisoryFilter(ids=advisories)):
                     for name, evr in packages:
                         patterns.add(name)
-                if patterns:
-                    lib.upgrade(patterns)
             else:
                 lib.upgrade(patterns)
             if self.commit:

--- a/src/katello/agent/pulp/libyum.py
+++ b/src/katello/agent/pulp/libyum.py
@@ -291,11 +291,12 @@ class Package(API):
                     'cves': []
                 }
                 updateinfo.update_minimal(lib)
-            if patterns:
-                for pattern in patterns:
-                    lib.update(pattern=str(pattern))
             else:
-                lib.update()
+                if patterns:
+                    for pattern in patterns:
+                        lib.update(pattern=str(pattern))
+                else:
+                    lib.update()
             lib.resolveDeps()
             if self.commit and len(lib.tsInfo):
                 lib.processTransaction()


### PR DESCRIPTION
https://projects.theforeman.org/issues/24081

Should only process `patterns` when `advisories` are _not_ specified.  Regression introduced while cleaning up ported pulp code.