### PR TITLE
Fixes #24214 - fill in vars on repo URLs

### DIFF
--- a/src/katello/enabled_report.py
+++ b/src/katello/enabled_report.py
@@ -13,7 +13,7 @@ class EnabledReport(object):
         config = ConfigParser()
         config.read(self.repofile)
         enabled_sections = [section for section in config.sections() if config.getboolean(section, "enabled")]
-        enabled_repos = [{"repositoryid": section,"baseurl": [config.get(section, "baseurl")]} for section in enabled_sections]
+        enabled_repos = [{"repositoryid": section,"baseurl": [self._replace_vars(config.get(section, "baseurl"))]} for section in enabled_sections]
         return {"enabled_repos": {"repos": enabled_repos}}
 
     def __init__(self, repo_file = REPOSITORY_PATH):
@@ -26,3 +26,32 @@ class EnabledReport(object):
 
     def __str__(self):
         return str(self.content)
+
+    def _replace_vars(self, repo_url):
+        """
+        returns a string with "$basearch" and "$releasever" replaced.
+
+        :param repo_url: a repo URL that you want to replace $basearch and $releasever in.
+        :type path: str
+        """
+        mappings = self._obtain_mappings()
+        return repo_url.replace('$releasever', mappings['releasever']).replace('$basearch', mappings['basearch'])
+
+    def _obtain_mappings(self):
+        """
+        returns a hash with "basearch" and "releasever" set. This will try dnf first, and them yum if dnf is not installed.
+        """
+        try:
+            return self._obtain_mappings_dnf()
+        except ImportError:
+            return self._obtain_mappings_yum()
+
+    def _obtain_mappings_dnf(self):
+        import dnf
+        db = dnf.dnf.Base()
+        return {'releasever': db.conf.substitutions['releasever'], 'basearch': db.conf.substitutions['basearch']}
+
+    def _obtain_mappings_yum(self):
+        import yum
+        yb = yum.YumBase()
+        return {'releasever': yb.conf.yumvar['releasever'], 'basearch': yb.conf.yumvar['basearch']}

--- a/test/test_katello/data/repos/redhat.repo.with_vars
+++ b/test/test_katello/data/repos/redhat.repo.with_vars
@@ -1,0 +1,36 @@
+[enabled_one]
+metadata_expire = 86400
+baseurl = https://enabled_repo.com/$releasever/$basearch
+ui_repoid_vars = basearch
+sslverify = 1
+name = Enabled Repo
+sslclientkey = /etc/pki/entitlement/3994-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[disabled_two]
+metadata_expire = 86400
+baseurl = https://enabled_repo_two.com/$releasever/$basearch
+ui_repoid_vars = basearch
+sslverify = 1
+name = Disnabled Repo
+sslclientkey = /etc/pki/entitlement/3994-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+
+[disabled]
+metadata_expire = 86400
+baseurl = https://disabled_repo.com
+ui_repoid_vars = basearch
+sslverify = 1
+name = Disabled Repo
+sslclientkey = /etc/pki/entitlement/3994-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+gpgcheck = 1
+

--- a/test/test_katello/test_enabled_report.py
+++ b/test/test_katello/test_enabled_report.py
@@ -19,3 +19,23 @@ class TestEnabledReport(TestCase):
                                'repositoryid': 'enabled'}]}}
 
         self.assertEqual(expected, report.content)
+
+    @patch('katello.enabled_report.EnabledReport._obtain_mappings_dnf')
+    def test_var_interpolation_dnf(self, mock_obtain_mappings_dnf):
+        mock_obtain_mappings_dnf.return_value = {'releasever': "6.22", 'basearch': "80286"}
+        rh_repo = os.path.join(os.path.dirname(__file__), 'data/repos/redhat.repo.with_vars')
+        report = enabled_report.EnabledReport(rh_repo)
+        expected = {'enabled_repos': {'repos': [{'baseurl': ['https://enabled_repo.com/6.22/80286'], 'repositoryid': 'enabled_one'}]}}
+
+        self.assertEqual(expected, report.content)
+
+    @patch('katello.enabled_report.EnabledReport._obtain_mappings_yum')
+    @patch('katello.enabled_report.EnabledReport._obtain_mappings_dnf')
+    def test_var_interpolation_yum(self, mock_obtain_mappings_dnf, mock_obtain_mappings_yum):
+        mock_obtain_mappings_dnf.side_effect = ImportError("dnf not available on 80286")
+        mock_obtain_mappings_yum.return_value = {'releasever': "6.22", 'basearch': "80286"}
+        rh_repo = os.path.join(os.path.dirname(__file__), 'data/repos/redhat.repo.with_vars')
+        report = enabled_report.EnabledReport(rh_repo)
+        expected = {'enabled_repos': {'repos': [{'baseurl': ['https://enabled_repo.com/6.22/80286'], 'repositoryid': 'enabled_one'}]}}
+
+        self.assertEqual(expected, report.content)


### PR DESCRIPTION
Previously, repo baseurls were sent as-is from redhat.repo to
Satellite. This resulted in the client reporting it was subscribed to
repos that don't exist, since the URLs would have the literal string
`$releasever/$basearch` in it.

This commit adds dnf and yum code to populate `$releasever` and
`$basearch`. It will attempt to use DNF libraries first, and if that
raises an `ImportError`, it will try yum.