### PR TITLE
fixes #25173 - Fix slow enabled report generation

### DIFF
--- a/src/katello/enabled_report.py
+++ b/src/katello/enabled_report.py
@@ -22,6 +22,7 @@ class EnabledReport(object):
         :param path: A .repo file path used to filter the report.
         :type path: str
         """
+        self.yb = yum.YumBase()
         self.repofile = repo_file
         self.content = self.__generate()
 
@@ -35,7 +36,7 @@ class EnabledReport(object):
         :param repo_url: a repo URL that you want to replace $basearch and $releasever in.
         :type path: str
         """
-        yb = yum.YumBase()
-        mappings = {'releasever': yb.conf.yumvar['releasever'], 'basearch': yb.conf.yumvar['basearch']}
+
+        mappings = {'releasever': self.yb.conf.yumvar['releasever'], 'basearch': self.yb.conf.yumvar['basearch']}
 
         return repo_url.replace('$releasever', mappings['releasever']).replace('$basearch', mappings['basearch'])


### PR DESCRIPTION
In its current state, this piece of the `enabled_repos_upload` yum/dnf plugin imports the `yum` or `dnf` Python module and creates an associated object each time `_replace_vars()` is executed. This can lead to time consuming yum operations if there are a large number of enabled yum repositories.

#### Example
A server has 13 enabled yum repositories. With `yum.YumBase()` being re-executed with each run of `_replace_vars()`. This results in the following output from a simple `yum check-update`:
```
# time yum check-update
Loaded plugins: enabled_repos_upload, fastestmirror, package_upload, product-id, search-disabled-repos, subscription-manager, tracer_upload
Loading mirror speeds from cached hostfile
Centos_Centos_7_Base
Centos_Centos_7_Extras
Centos_Centos_7_Updates
Centos_Centos_sclo
Centos_Centos_sclo-rh
Datadog_Datadog
EPEL_EPEL_Centos7
Extra_rpm-extra
Katello-agent_agent-3_7
MySQL_Enterprise_MySQL_Enterprise
Puppet_puppet_4
Zabbix_Zabbix_3_2
Uploading Enabled Repositories Report
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager
Loaded plugins: fastestmirror, product-id, subscription-manager

real	0m35.492s
user	0m8.330s
sys	0m0.611s
```

The output is excessively long and it takes 35 seconds to tell me that nothing is available to update. With this PR in place, it only takes 6 seconds and the output is much shorter:
```
# time yum check-update
Loaded plugins: enabled_repos_upload, fastestmirror, package_upload, product-id, search-disabled-repos, subscription-manager, tracer_upload
Loading mirror speeds from cached hostfile
Centos_Centos_7_Base
Centos_Centos_7_Extras
Centos_Centos_7_Updates
Centos_Centos_sclo
Centos_Centos_sclo-rh
Datadog_Datadog
EPEL_EPEL_Centos7
Extra_rpm-extra
Katello-agent_agent-3_7
MySQL_Enterprise_MySQL_Enterprise
Puppet_puppet_4
Zabbix_Zabbix_3_2
Uploading Enabled Repositories Report
Loaded plugins: fastestmirror, product-id, subscription-manager

real	0m6.351s
user	0m3.058s
sys	0m0.417s
```