### PR TITLE
Fixes #25725 - disable plugins if we have subman profiles

### DIFF
--- a/src/katello/utils.py
+++ b/src/katello/utils.py
@@ -7,7 +7,7 @@ else:
     from ConfigParser import ConfigParser
 
 def plugin_enabled(filepath, environment_variable, force = False):
-    return force or (config_enabled(filepath) and not environment_disabled(environment_variable ))
+    return (force or (config_enabled(filepath) and not environment_disabled(environment_variable))) and not subman_profile_enabled()
 
 def config_enabled(filepath):
     try:
@@ -19,3 +19,8 @@ def config_enabled(filepath):
 
 def environment_disabled(variable):
     return variable in environ and environ[variable] != ''
+
+def subman_profile_enabled():
+    # subscription-manager versions containing this module
+    # provide package-upload and enabled-repos-upload capability
+    return 'rhsm.profile.EnabledReposProfile' in sys.modules

--- a/test/test_katello/test_packages.py
+++ b/test/test_katello/test_packages.py
@@ -9,10 +9,10 @@ from mock import patch
 
 
 class TestUploadPackageProfile(TestCase):
+    @patch('katello.packages.plugin_enabled', return_value=True)
     @patch('katello.packages.get_manager')
     @patch('katello.packages.lookup_consumer_id')
-    @patch('katello.packages.PACKAGE_PROFILE_PLUGIN_CONF', 'test/test_katello/data/plugin_conf/enabled.conf')
-    def test_upload_registered(self, mock_lookup, mock_manager):
+    def test_upload_registered(self, mock_lookup, mock_manager, plugin_enabled):
         mock_lookup.return_value = True
 
         upload_package_profile()

--- a/test/test_katello/test_utils.py
+++ b/test/test_katello/test_utils.py
@@ -1,45 +1,68 @@
 import os
 import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
 from unittest import TestCase
+
+from mock import Mock, patch
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
 
 from katello import utils
 
-from mock import patch
+
+if sys.version_info[0] == 3:
+    from configparser import NoOptionError
+else:
+    from ConfigParser import NoOptionError
 
 ENABLED_CONF = 'test/test_katello/data/plugin_conf/enabled.conf'
 DISABLED_CONF = 'test/test_katello/data/plugin_conf/disabled.conf'
 
+
 class TestPluginEnabled(TestCase):
     @patch('katello.utils.subman_profile_enabled', return_value=False)
     def test_conf_enabled(self, mock_subman):
-        self.assertTrue(utils.plugin_enabled(ENABLED_CONF, 'somevar'))
+        self.assertTrue(utils.plugin_enabled(ENABLED_CONF))
 
     @patch('katello.utils.subman_profile_enabled', return_value=False)
     def test_conf_disabled(self, mock_subman):
-        conf = 'test/test_katello/data/plugin_conf/disabled.conf'
-        self.assertFalse(utils.plugin_enabled(DISABLED_CONF, 'somevar'))
+        self.assertFalse(utils.plugin_enabled(DISABLED_CONF))
 
     @patch('katello.utils.subman_profile_enabled', return_value=False)
     def test_conf_disabled_force(self, mock_subman):
-        self.assertTrue(utils.plugin_enabled(DISABLED_CONF, 'somevar', True))
+        self.assertTrue(utils.plugin_enabled(DISABLED_CONF, None, True))
 
     @patch('katello.utils.subman_profile_enabled', return_value=False)
     def test_env_disabled(self, mock_subman):
         os.environ['testa'] = 'true'
-        self.assertFalse(utils.plugin_enabled(ENABLED_CONF, 'testa', False))
+        self.assertFalse(utils.plugin_enabled(ENABLED_CONF, 'testa'))
 
     @patch('katello.utils.subman_profile_enabled', return_value=False)
     def test_env_disabled_force(self, mock_subman):
         os.environ['testa'] = 'true'
         self.assertTrue(utils.plugin_enabled(ENABLED_CONF, 'testa', True))
 
-    def test_subman_profile_module_present(self):
-        sys.modules["rhsm.profile.EnabledReposProfile"] = True
-        self.assertFalse(utils.plugin_enabled(ENABLED_CONF, 'somevar'))
+    @patch('katello.utils.rhsmConfig.initConfig')
+    def test_subman_profile_enabled(self, mock_init):
+        mock_config = Mock()
+        mock_init.return_value = mock_config
+        mock_config.get.return_value = '1'
 
-    def test_subman_profile_module_missing(self):
-        if "rhsm.profile.EnabledReposProfile" in sys.modules:
-            del sys.modules["rhsm.profile.EnabledReposProfile"]
+        self.assertFalse(utils.plugin_enabled(ENABLED_CONF))
+        mock_config.get.assert_called_with('rhsm', 'package_profile_on_trans')
 
-        self.assertTrue(utils.plugin_enabled(ENABLED_CONF, 'somevar'))
+    @patch('katello.utils.rhsmConfig.initConfig')
+    def test_subman_profile_enabled_disabled(self, mock_init):
+        mock_config = Mock()
+        mock_init.return_value = mock_config
+        mock_config.get.return_value = '0'
+
+        self.assertTrue(utils.plugin_enabled(ENABLED_CONF))
+        mock_config.get.assert_called_with('rhsm', 'package_profile_on_trans')
+
+    @patch('katello.utils.rhsmConfig.initConfig')
+    def test_subman_profile_enabled_missing_config_key(self, mock_init):
+        mock_config = Mock()
+        mock_init.return_value = mock_config
+        mock_config.get.side_effect = NoOptionError('rhsm', 'package_profile_on_trans')
+
+        self.assertTrue(utils.plugin_enabled(ENABLED_CONF))
+        mock_config.get.assert_called_with('rhsm', 'package_profile_on_trans')

--- a/test/test_katello/test_utils.py
+++ b/test/test_katello/test_utils.py
@@ -10,21 +10,36 @@ from mock import patch
 ENABLED_CONF = 'test/test_katello/data/plugin_conf/enabled.conf'
 DISABLED_CONF = 'test/test_katello/data/plugin_conf/disabled.conf'
 
-class TestUtils(TestCase):
-    def test_plugin_enabled(self):
+class TestPluginEnabled(TestCase):
+    @patch('katello.utils.subman_profile_enabled', return_value=False)
+    def test_conf_enabled(self, mock_subman):
         self.assertTrue(utils.plugin_enabled(ENABLED_CONF, 'somevar'))
 
-    def test_plugin_enabled_disabled(self):
+    @patch('katello.utils.subman_profile_enabled', return_value=False)
+    def test_conf_disabled(self, mock_subman):
         conf = 'test/test_katello/data/plugin_conf/disabled.conf'
         self.assertFalse(utils.plugin_enabled(DISABLED_CONF, 'somevar'))
 
-    def test_plugin_enabled_disabled_force(self):
+    @patch('katello.utils.subman_profile_enabled', return_value=False)
+    def test_conf_disabled_force(self, mock_subman):
         self.assertTrue(utils.plugin_enabled(DISABLED_CONF, 'somevar', True))
 
-    def test_plugin_enabled_disabled_var(self):
+    @patch('katello.utils.subman_profile_enabled', return_value=False)
+    def test_env_disabled(self, mock_subman):
         os.environ['testa'] = 'true'
         self.assertFalse(utils.plugin_enabled(ENABLED_CONF, 'testa', False))
 
-    def test_plugin_enabled_disabled_var_force(self):
+    @patch('katello.utils.subman_profile_enabled', return_value=False)
+    def test_env_disabled_force(self, mock_subman):
         os.environ['testa'] = 'true'
         self.assertTrue(utils.plugin_enabled(ENABLED_CONF, 'testa', True))
+
+    def test_subman_profile_module_present(self):
+        sys.modules["rhsm.profile.EnabledReposProfile"] = True
+        self.assertFalse(utils.plugin_enabled(ENABLED_CONF, 'somevar'))
+
+    def test_subman_profile_module_missing(self):
+        if "rhsm.profile.EnabledReposProfile" in sys.modules:
+            del sys.modules["rhsm.profile.EnabledReposProfile"]
+
+        self.assertTrue(utils.plugin_enabled(ENABLED_CONF, 'somevar'))

--- a/test/test_yum_plugins/test_enabled_repos_upload.py
+++ b/test/test_yum_plugins/test_enabled_repos_upload.py
@@ -17,14 +17,14 @@ except ImportError:
 FAKE_REPORT = {'foobar': 1}
 
 class TestSendEnabledReport(unittest.TestCase):
+    @patch('katello.repos.plugin_enabled', return_value=True)
     @patch('enabled_repos_upload.EnabledReport')
     @patch('katello.uep.ConsumerIdentity.read')
     @patch('katello.repos.report_enabled_repos')
     @patch('katello.repos.EnabledRepoCache.is_valid')
     @patch('katello.repos.EnabledRepoCache.save')
-    @patch('katello.repos.ENABLED_REPOS_PLUGIN_CONF', 'test/test_katello/data/plugin_conf/enabled.conf')
     @unittest.skipIf(sys.version_info[0] > 2, "yum tests for PY2 only")
-    def test_send(self, cache_save, cache_valid, fake_report_enabled, fake_read, fake_report):
+    def test_send(self, cache_save, cache_valid, fake_report_enabled, fake_read, fake_report, plugin_enabled):
         consumer_id = '1234'
         fake_certificate = Mock()
         fake_certificate.getConsumerId.return_value = consumer_id
@@ -41,14 +41,14 @@ class TestSendEnabledReport(unittest.TestCase):
         fake_certificate.getConsumerId.assert_called_with()
         fake_report_enabled.assert_called_with(consumer_id, FAKE_REPORT)
 
+    @patch('katello.repos.plugin_enabled', return_value=True)
     @patch('enabled_repos_upload.EnabledReport')
     @patch('katello.uep.ConsumerIdentity.read')
     @patch('katello.repos.report_enabled_repos')
     @patch('katello.repos.EnabledRepoCache.is_valid')
     @patch('katello.repos.EnabledRepoCache.save')
-    @patch('katello.repos.ENABLED_REPOS_PLUGIN_CONF', 'test/test_katello/data/plugin_conf/enabled.conf')
     @unittest.skipIf(sys.version_info[0] > 2, "yum tests for PY2 only")
-    def test_cached(self, cache_save, cache_valid, fake_report_enabled, fake_read, fake_report):
+    def test_cached(self, cache_save, cache_valid, fake_report_enabled, fake_read, fake_report, plugin_enabled):
         consumer_id = '1234'
         fake_certificate = Mock()
         fake_certificate.getConsumerId.return_value = consumer_id

--- a/test/unittest_suite.py
+++ b/test/unittest_suite.py
@@ -8,6 +8,7 @@ if sys.version_info[0] == 2:
         'test_katello.test_enabled_report',
         'test_katello.test_packages',
         'test_katello.test_repos',
+        'test_katello.test_utils',
         'test_rhsm_fact_plugin',
         'test_yum_plugins.test_enabled_repos_upload',
         'zypper_plugins.test_enabled_repos_upload'


### PR DESCRIPTION
This code will automatically disable enabled_repos_upload and package_upload plugins when it detects that a subscription-manager supporting the same is installed.

There are many ways to test this, here's one:

1. spin up a katello-client, registered to some server
2. check out this PR on the client
3. symlink the previously installed katello utils.py to your git checkout of this PR to use the new code `/usr/lib/python2.7/site-packages/katello/utils.py`

If you're using subscription-manager >= 1.23 the package & repos plugins should not send data to the server after a yum transaction, but they will function as usual for lower versions.