### PR TITLE
add a katello-tracer-upload wrapper for the dnf plugin

### DIFF
--- a/extra/katello-tracer-upload-dnf
+++ b/extra/katello-tracer-upload-dnf
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dnf katello-tracer-upload $@


### PR DESCRIPTION
many places (like our own cron file) reference the katello-tracer-upload
binary, but we don't actually build/ship that binary on dnf-based
distros.