### PR TITLE
Fixes #26363 - Don't exit transaction when tracer plugin is broken

### DIFF
--- a/src/katello/tracer.py
+++ b/src/katello/tracer.py
@@ -4,10 +4,7 @@ import sys
 
 from katello.uep import get_uep, lookup_consumer_id
 
-try:
-    from tracer.query import Query
-except ImportError:
-    sys.exit('Error Importing tracer! Is tracer installed?')
+from tracer.query import Query
 
 
 def upload_tracer_profile(queryfunc, plugin):


### PR DESCRIPTION
before:
```
[root@fedora28 katello-host-tools]# dnf install wget                                                    
Error Importing tracer! Is tracer installed?  
```

after:

```
[root@fedora28 src]# dnf install wget                                                                                                                                                             
Failed loading plugin: tracer_upload                                                                                                                                                               
Updating Subscription Management repositories.
This system is registered to Red Hat Subscription Management, but is not receiving updates. You can use subscription-manager to assign subscriptions.
Updating Subscription Management repositories.
This system is registered to Red Hat Subscription Management, but is not receiving updates. You can use subscription-manager to assign subscriptions.
Last metadata expiration check: 5:14:24 ago on Mon 25 Mar 2019 01:38:20 PM UTC.
Package wget-1.20.1-1.fc28.x86_64 is already installed, skipping.
Dependencies resolved.
Nothing to do.
Complete!

```