### PR TITLE
Add Suse Leap and Fedora 30 test containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ matrix:
     - env: DOCKERFILE=images/Dockerfile.el6
     - env: DOCKERFILE=images/Dockerfile.el7
     - env: DOCKERFILE=images/Dockerfile.f29
+    - env: DOCKERFILE=images/Dockerfile.f30
+    - env: DOCKERFILE=images/Dockerfile.suseLeap42
 
 script: make docker-test

--- a/images/Dockerfile.f30
+++ b/images/Dockerfile.f30
@@ -1,0 +1,4 @@
+FROM fedora:30
+
+RUN dnf install make python3-gofer python3-dnf-plugins-core python3-tracer python3-gofer-proton subscription-manager -y && yum clean all
+WORKDIR /app

--- a/images/Dockerfile.suseLeap42
+++ b/images/Dockerfile.suseLeap42
@@ -1,0 +1,7 @@
+FROM opensuse/leap:42
+
+RUN zypper addrepo -c --no-gpgcheck https://download.opensuse.org/repositories/home:/kahowell/openSUSE_Leap_42.2/ subscription-manager
+
+RUN zypper install -y subscription-manager python-pip make zypp-plugin-python && zypper clean
+
+WORKDIR /app

--- a/src/zypper_plugins/package_upload.py
+++ b/src/zypper_plugins/package_upload.py
@@ -66,14 +66,14 @@ class KatelloZyppPlugin(Plugin):
         self.ack()
 
 
-if "DISABLE_KATELLO_ZYPP_PLUGIN" in environ:
+if __name__ == '__main__':
+    if "DISABLE_KATELLO_ZYPP_PLUGIN" in environ:
+        logging.info("$DISABLE_KATELLO_ZYPP_PLUGIN is set - disabling katello-zypp-plugin")
 
-    logging.info("$DISABLE_KATELLO_ZYPP_PLUGIN is set - disabling katello-zypp-plugin")
+        # As the plugin is disabled, we are adding a dummy
+        # Plugin so that zypper still works.
+        plugin = Plugin()
+    else:
+        plugin = KatelloZyppPlugin()
 
-    # As the plugin is disabled, we are adding a dummy
-    # Plugin so that zypper still works.
-    plugin = Plugin()
-    plugin.main()
-else:
-    plugin = KatelloZyppPlugin()
     plugin.main()

--- a/test/unittest_suite.py
+++ b/test/unittest_suite.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 import sys
+
 import unittest2 as unittest
+
 
 if sys.version_info[0] == 2:
     modules = [
@@ -9,19 +11,29 @@ if sys.version_info[0] == 2:
         'test_katello.test_packages',
         'test_katello.test_repos',
         'test_katello.test_utils',
-        'test_rhsm_fact_plugin',
-        'test_yum_plugins.test_enabled_repos_upload',
-        'zypper_plugins.test_enabled_repos_upload',
-        'zypper_plugins.test_tracer_upload'
+        'test_rhsm_fact_plugin'
     ]
 
-    if sys.version_info[1] > 6:
-        modules.append('test_katello.test_plugin')
-        modules.append('test_katello.test_agent.test_pulp.test_handler')
-        modules.append('test_katello.test_agent.test_pulp.test_libyum')
+    try:
+        import zypp_plugin
+        zypper_enabled = True
+    except ImportError:
+        zypper_enabled = False
+
+    if zypper_enabled:
+        modules.append('zypper_plugins.test_enabled_repos_upload')
+        modules.append('zypper_plugins.test_package_upload')
+        modules.append('zypper_plugins.test_tracer_upload')
     else:
-        # this test file doesn't start with test_ to avoid py3 unittest discovery
-        modules.append('test_katello.legacy_plugin_test')
+        modules.append('test_yum_plugins.test_enabled_repos_upload')
+
+        if sys.version_info[1] > 6:
+            modules.append('test_katello.test_plugin')
+            modules.append('test_katello.test_agent.test_pulp.test_handler')
+            modules.append('test_katello.test_agent.test_pulp.test_libyum')
+        else:
+            # this test file doesn't start with test_ to avoid py3 unittest discovery
+            modules.append('test_katello.legacy_plugin_test')
 
     map(__import__, modules)
 

--- a/test/zypper_plugins/test_package_upload.py
+++ b/test/zypper_plugins/test_package_upload.py
@@ -8,17 +8,17 @@ from mock import Mock, patch
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/zypper_plugins'))
-    import enabled_repos_upload
+    import package_upload
 except:
   pass
 
-class TestEnabledReposUpload(TestCase):
+class TestPackageUpload(TestCase):
     def setUp(self):
-        self.plugin = enabled_repos_upload.EnabledReposUpload()
+        self.plugin = package_upload.KatelloZyppPlugin()
 
     @unittest.skipIf('zypp_plugin' not in sys.modules, "zypper not present")
-    @patch('enabled_repos_upload.upload_enabled_repos_report')
-    def test_plugin_enabled(self, upload_report):
+    @patch('package_upload.upload_package_profile')
+    def test_plugin_enabled(self, upload_package_profile):
         self.plugin.PLUGINEND({}, {})
 
-        assert upload_report.called
+        assert upload_package_profile.called


### PR DESCRIPTION
This PR:

- Adds a Fedora 30 image for tests
- Adds a Suse Leap 42 image for tests
- Adds the new images to the travis test matrix
- Adds tests for Zypper package upload plugin

Since we have 3 Zypper plugins now it's important to have this. While we actually support SLES only, it's not feasible - as far as I know - to get this working nearly as simply as using suse leap.