### PR TITLE
Update katello-package-upload -f to remove the combined profile cache

### DIFF
--- a/src/katello/constants.py
+++ b/src/katello/constants.py
@@ -1,5 +1,6 @@
 ENABLED_REPOS_CACHE_FILE = '/var/cache/katello-agent/enabled_repos.json'
 PACKAGE_CACHE_FILE = '/var/lib/rhsm/packages/packages.json'
+COMBINED_PROFILE_CACHE_FILE = '/var/lib/rhsm/cache/profile.json'
 REPOSITORY_PATH = '/etc/yum.repos.d/redhat.repo'
 ZYPPER_REPOSITORY_PATH = '/etc/rhsm/zypper.repos.d/redhat.repo'
 

--- a/src/katello/packages.py
+++ b/src/katello/packages.py
@@ -2,7 +2,7 @@ import errno
 import os
 import sys
 
-from katello.constants import PACKAGE_CACHE_FILE, PACKAGE_PROFILE_PLUGIN_CONF, DISABLE_PACKAGE_PROFILE_VAR
+from katello.constants import PACKAGE_CACHE_FILE, PACKAGE_PROFILE_PLUGIN_CONF, DISABLE_PACKAGE_PROFILE_VAR, COMBINED_PROFILE_CACHE_FILE
 from katello.uep import get_manager, lookup_consumer_id
 from katello.utils import plugin_enabled
 
@@ -18,9 +18,10 @@ def upload_package_profile(force=False):
 
 
 def purge_package_cache():
-    try:
-        os.remove(PACKAGE_CACHE_FILE)
-    except OSError:
-        error = sys.exc_info()[1]  # backward and forward compatible way to get the exception
-        if error.errno is not errno.ENOENT:
-            sys.stderr.write("Unable to clear the package cache")
+    for cache_file in [PACKAGE_CACHE_FILE, COMBINED_PROFILE_CACHE_FILE]:
+        try:
+            os.remove(cache_file)
+        except OSError:
+            error = sys.exc_info()[1]  # backward and forward compatible way to get the exception
+            if error.errno is not errno.ENOENT:
+                sys.stderr.write("Unable to clear the package cache: " + cache_file)


### PR DESCRIPTION
As of commit 8a5416cf50074dd700414bb0b0d89c4bf414e1a9 in
candlepin/subscription-manager, the file /var/lib/rhsm/packages/packages.json
is no longer used to track the installed packages.
This changes the purge_package_cache function to remove either the old
file or the new one '/var/lib/rhsm/cache/profile.json'.