### PR TITLE
fixes #27912 - Disable debug output from yum

### DIFF
--- a/src/katello/enabled_report.py
+++ b/src/katello/enabled_report.py
@@ -23,6 +23,7 @@ class EnabledReport(object):
         :type path: str
         """
         self.yb = yum.YumBase()
+        self.yb.preconf.debuglevel = 0
         self.repofile = repo_file
         self.content = self.__generate()
 


### PR DESCRIPTION
By setting the debuglevel to 0 we disable the `Loaded plugins: fastestmirror, product-id, subscription-manager` that `YumBase` would emit otherwise.

After applying this change the output would be:
```
Loaded plugins: enabled_repos_upload, fastestmirror, product-id, search-disabled-repos, subscription-manager

java-1.8.0-openjdk.x86_64                                                                                                                                        1:1.8.0.222.b10-1.el7_7                                                                                                                               updates
java-1.8.0-openjdk-headless.x86_64                                                                                                                               1:1.8.0.222.b10-1.el7_7                                                                                                                               updates
Uploading Enabled Repositories Report
[root@foreman pluginconf.d]# vi^C
[root@foreman pluginconf.d]# vi /usr/lib/python2.7/site-packages/katello/enabled_report.py
[root@foreman pluginconf.d]# /usr/bin/yum -C check-update
Loaded plugins: enabled_repos_upload, fastestmirror, product-id, search-disabled-repos, subscription-manager

java-1.8.0-openjdk.x86_64                                                                                                                                        1:1.8.0.222.b10-1.el7_7                                                                                                                               updates
java-1.8.0-openjdk-headless.x86_64                                                                                                                               1:1.8.0.222.b10-1.el7_7                                                                                                                               updates
Uploading Enabled Repositories Report
```
without it another extra line at the bottom would be:
```
Loaded plugins: fastestmirror, product-id, subscription-manager
```
Disabling this output is helpful because it breaks nagios yum checks which don't expect this message at this point. Also for the nagios checks to work one needs to remove `Uploading Enabled Repositories Report` by setting `supress_debug=True` in the plugin config)