### PR TITLE
Fixes #28449 - katello-agent no qpid connection w/ gofer 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     - env: DOCKERFILE=images/Dockerfile.el7
     - env: DOCKERFILE=images/Dockerfile.f29
     - env: DOCKERFILE=images/Dockerfile.f30
+    - env: DOCKERFILE=images/Dockerfile.f31
     - env: DOCKERFILE=images/Dockerfile.suseLeap42
 
 script: make docker-test

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ PYTHON ?= python
 PIP ?= pip
 endif
 
+PODMAN=$(shell command -v podman)
+ifneq ($(PODMAN),)
+CONTAINER_EXEC ?= podman
+else
+CONTAINER_EXEC ?= docker
+endif
+
 default: help
 
 help:
@@ -43,10 +50,10 @@ test: test-install
 	$(PYTHON) test/unittest_suite.py
 
 docker-build:
-	docker build -f $(DOCKERFILE) -t kht-builder .
+	$(CONTAINER_EXEC) build -f $(DOCKERFILE) -t kht-builder .
 
 docker-run: docker-build
-	docker run --rm -itv $(CURDIR):/app$(USE_SELINUX) kht-builder bash
+	$(CONTAINER_EXEC) run --rm -itv $(CURDIR):/app$(USE_SELINUX) kht-builder bash
 
 docker-test: docker-build
-	docker run --rm -itv $(CURDIR):/app$(USE_SELINUX) kht-builder ./test/test_runner.sh
+	$(CONTAINER_EXEC) run --rm -itv $(CURDIR):/app$(USE_SELINUX) kht-builder ./test/test_runner.sh

--- a/images/Dockerfile.el5
+++ b/images/Dockerfile.el5
@@ -6,7 +6,7 @@ RUN yum install -y wget make python-setuptools python-ctypes python-hashlib pyth
 # this repo provides a wget that support tls 1.1
 RUN wget http://www.tuxad.de/repo/5/tuxad.rpm
 RUN rpm -Uhv tuxad.rpm
-RUN yum upgrade -y wget && yum clean all
+RUN yum upgrade -y wget --nogpgcheck && yum clean all
 
 RUN wget -r --no-parent https://fedorapeople.org/groups/katello/releases/yum/3.3/client/el5/x86_64/ --no-check-certificate
 WORKDIR /fedorapeople.org/groups/katello/releases/yum/3.3/client/el5/x86_64/

--- a/images/Dockerfile.f31
+++ b/images/Dockerfile.f31
@@ -1,0 +1,4 @@
+FROM fedora:31
+
+RUN dnf install pip make python3-gofer python3-dnf-plugins-core python3-tracer python3-gofer-proton subscription-manager -y && yum clean all
+WORKDIR /app

--- a/src/katello/agent/goferd/plugin.py
+++ b/src/katello/agent/goferd/plugin.py
@@ -163,7 +163,7 @@ def update_settings():
 
     plugin.cfg.messaging.cacert = existing_ca_certs[0]
     plugin.cfg.messaging.url = 'proton+amqps://%s:5647' % rhsm_conf['server']['hostname']
-    plugin.cfg.messaging.uuid = 'pulp.agent.%s' % certificate.getConsumerId()
+    plugin.cfg.model.queue = 'pulp.agent.%s' % certificate.getConsumerId()
     bundle(certificate)
 
 

--- a/test/test_katello/test_plugin.py
+++ b/test/test_katello/test_plugin.py
@@ -41,6 +41,7 @@ class PluginTest(unittest.TestCase):
         plugin._module = plugin
         plugin_cfg = Mock()
         plugin_cfg.messaging = Mock()
+        plugin_cfg.model = Mock()
         plugin.plugin = Mock()
         plugin.plugin.scheduler = Mock()
         plugin.plugin.scheduler.pending = Mock(PENDING='/tmp/pending', stream='abc')
@@ -177,7 +178,7 @@ class TestUpdateSettings(PluginTest):
         plugin_cfg = self.plugin.plugin.cfg
         self.assertEqual(plugin_cfg.messaging.cacert, default_ca_cert)
         self.assertEqual(plugin_cfg.messaging.url, 'proton+amqps://%s:5647' % self.host)
-        self.assertEqual(plugin_cfg.messaging.uuid, 'pulp.agent.%s' % consumer_id)
+        self.assertEqual(plugin_cfg.model.queue, 'pulp.agent.%s' % consumer_id)
 
 
 @unittest.skipIf(sys.version_info[0] == 2 and sys.version_info[1] < 7, "goferd plugin requires python 2.7+")


### PR DESCRIPTION
**To test**
Spin up a fedora30 client and register it to your katello
Install katello-agent from the nightly repos (3.5.1)

Observe that package actions (ie install package) via katello-agent does not complete successfully.

Apply the patch here to plugin.py and restart goferd. The previous package action should be picked up (journalctl -xaf) and any new package actions should succeed as normal