### PR TITLE
Fixes #28909 - Enabled libdnf update all

### DIFF
--- a/src/katello/agent/pulp/libdnf.py
+++ b/src/katello/agent/pulp/libdnf.py
@@ -257,8 +257,7 @@ class Package(API):
                 for ad, packages in lib.applicable_advisories(AdvisoryFilter(ids=advisories)):
                     for name, evr in packages:
                         patterns.add(name)
-            if patterns:
-                lib.upgrade(patterns)
+            lib.upgrade(patterns)
 
             if self.commit:
                 lib.do_transaction()

--- a/src/katello/agent/pulp/libdnf.py
+++ b/src/katello/agent/pulp/libdnf.py
@@ -257,8 +257,10 @@ class Package(API):
                 for ad, packages in lib.applicable_advisories(AdvisoryFilter(ids=advisories)):
                     for name, evr in packages:
                         patterns.add(name)
-            lib.upgrade(patterns)
-
+                if patterns:
+                   lib.upgrade(patterns)
+            else:
+                lib.upgrade(patterns)
             if self.commit:
                 lib.do_transaction()
             report = UpdateTxReport(lib.transaction or ())

--- a/test/test_katello/test_agent/test_pulp/test_libdnf.py
+++ b/test/test_katello/test_agent/test_pulp/test_libdnf.py
@@ -26,3 +26,14 @@ class TestLibDnf(unittest.TestCase):
         #strip the evrs out of the package
         packages = set([pack[0] for pack in packages])
         mock_libdnf.upgrade.assert_called_with(packages)
+
+  def test_package_update_all(self):
+      advisories = set()
+      packages = set()
+      mock_libdnf = MagicMock()
+      mock_libdnf.__enter__ = lambda instance: instance
+      with patch('katello.agent.pulp.libdnf.LibDnf', return_value= mock_libdnf):
+        package = libdnf.Package()
+        package.update(packages, advisories)
+        #strip the evrs out of the package
+        mock_libdnf.upgrade.assert_called_with(packages)


### PR DESCRIPTION
The katello agent for libdnf based systems was ignoring the "update all
packages" call. It would see no patterns and not execute the update.
This commit fixes that by running an update all on empty pattern set.