### PR TITLE
Fixes #28962 - Lock mock version < 4.0.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 flake8; python_version >= '2.7'
-mock; python_version >= '2.7'
+mock<4.0.0; python_version >= '2.7'
 unittest2


### PR DESCRIPTION
mock 4.0.0 broke our tests, so locking the version for now

https://github.com/testing-cabal/mock/issues/486