### PR TITLE
Fixes #29691 - Prevent generating invalid package patterns for yum

### DIFF
--- a/src/katello/agent/pulp/libyum.py
+++ b/src/katello/agent/pulp/libyum.py
@@ -36,7 +36,15 @@ class Pattern(object):
         'arch',
     )
 
-    def __init__(self, name, epoch='*', version='*', release='*', arch='*'):
+    FIELDS = (
+        ('epoch', ('', ':')),
+        ('name', ('', '')),
+        ('version', ('-', '')),
+        ('release', ('-', '')),
+        ('arch', ('.', '')),
+    )
+
+    def __init__(self, name, epoch='', version='', release='', arch=''):
         """
         NEVRA
 
@@ -57,13 +65,17 @@ class Pattern(object):
        return str(self) == str(other)
 
     def __str__(self):
-        fmt = '{epoch}:{name}-{version}-{release}.{arch}'
-        return fmt.format(
-            epoch=self.epoch,
-            name=self.name,
-            version=self.version,
-            release=self.release,
-            arch=self.arch)
+        pattern = []
+        for name, sep in self.FIELDS:
+            value = getattr(self, name)
+            if not value:
+                continue
+            if sep[0]:
+                pattern.append(sep[0])
+            pattern.append(value)
+            if sep[1]:
+                pattern.append(sep[1])
+        return ''.join(pattern)
 
 
 class TransactionReport(object):


### PR DESCRIPTION
Installing package from the UI for a yum client was not working:

```
May  4 15:57:29 katello-client goferd: [ERROR][worker-0] katello.agent.pulp.dispatcher:82 - InstallError: *:katello-host-tools-tracer.*: No package(s) available to install
```

This change is consistent with libdnf: https://github.com/Katello/katello-host-tools/blob/master/src/katello/agent/pulp/libdnf.py

**Witness the broken behavior**
- Register a content host such as katello-client and install katello-agent
- From the UI, navigate to the host details and go to Packages -> Actions
- Enter a package name such as katello-host-tools-tracer and 'Perform'
- Notice the task fails as shown above

**Test the fix**
- Update libyum.py on the client with the version from this PR (use 'raw')
`curl <url of libyum.py from this pr> > /path/on/client/libyum.py`
- `systemctl restart goferd` on the client
- repeating the steps above should get the package installed - you can confirm on the client with `rpm -q katello-host-tools-tracer`
