### PR TITLE
Fixes #29824 - Rely on Tracer to find affected packages for DNF

### DIFF
--- a/src/yum-plugins/tracer_upload.py
+++ b/src/yum-plugins/tracer_upload.py
@@ -14,9 +14,11 @@ def query_apps(conduit):
 
     # When running via yum we need to pass tracer a list of packages and
     # their last modified time so it has no need to access the rpmdb (which
-    # would fail as yum/dnf has a lock on it)
+    # would fail as yum has a lock on it)
     packages = []
-    pkgs = conduit.getTsInfo().getMembers()  # Packages in the current transation
+
+    # Packages in the current transation
+    pkgs = conduit.getTsInfo().getMembers()
     for pkg in pkgs:
         pkg.modified = time.time()
         packages.append(pkg)


### PR DESCRIPTION
This should be tested in conjunction with https://github.com/FrostyX/tracer/pull/141 and https://github.com/Katello/katello/pull/8712 to save time and make sure everything works together!

This requires a regression test of both EL7 and EL8 in this fashion:

- apply https://github.com/Katello/katello/pull/8712 your katello server
- register an EL7 client and subscribe to RHEL base
- install katello-host-tools-tracer on the client
- patch tracer and katello-host-tools-tracer with this code and https://github.com/FrostyX/tracer/pull/141
- upgrade some packages (tuned, auditd, kernel) which will create some traces (note them in the UI)
- run katello-tracer-upload - the traces should be virtually identical to what was already there
- run `tracer --user * -av` and compare the output to the UI - it should be virtually identical

Repeat steps for EL8!