### PR TITLE
Fixes #32450: Load system configuration when calling dnf

### DIFF
--- a/src/katello/agent/pulp/libdnf.py
+++ b/src/katello/agent/pulp/libdnf.py
@@ -412,6 +412,7 @@ class LibDnf(dnf.Base):
         """
         super(LibDnf, self).__init__()
         self.conf.assumeyes = True
+        self.conf.substitutions.update_from_etc("/")
 
     def open(self):
         """


### PR DESCRIPTION
When DNF is used via the API, the system configuration is not
loaded. This can cause OSes like Centos 8 stream to fail to
load repositories when doing variable substitution.