### PR TITLE
Use http for Suse Leap container build

### DIFF
--- a/images/Dockerfile.suseLeap42
+++ b/images/Dockerfile.suseLeap42
@@ -1,6 +1,6 @@
 FROM opensuse/leap:42
 
-RUN zypper addrepo -c --no-gpgcheck https://download.opensuse.org/repositories/home:/kahowell/openSUSE_Leap_42.2/ subscription-manager
+RUN zypper addrepo -c --no-gpgcheck http://download.opensuse.org/repositories/home:/kahowell/openSUSE_Leap_42.2/ subscription-manager
 
 RUN zypper install -y subscription-manager python-pip make zypp-plugin-python && zypper clean
 


### PR DESCRIPTION
The addrepo command is failing due to the system being unaware of the new letsencrypt CA. This gets it passing again and I think it's OK to use http here since these containers are not for any kind of deployment