### PR TITLE
Make sure commands used by katello-tracer-upload can be found

### DIFF
--- a/extra/katello-tracer-upload.cron
+++ b/extra/katello-tracer-upload.cron
@@ -1,2 +1,2 @@
 # Send a new Tracer report after a reboot
-@reboot root sleep 60 && /sbin/katello-tracer-upload > /dev/null 2>&1
+@reboot root sleep 60 && PATH=/usr/sbin:/usr/bin:/sbin:/bin /sbin/katello-tracer-upload >/dev/null 2>&1


### PR DESCRIPTION
katello-tracer-upload for debian/ubuntu uses deb_tracer.py and in the end "needrestart" is used. needrestart is in /usr/sbin/. On Debian/Ubuntu, "@reboot" jobs have only PATH=/usr/bin/ set. Therefore its necessary to set the PATH variable so that needrestart can be found. 