### PR TITLE
Fixes #35759 - specify package evr when updating via errata to match upgrade-minimal

### DIFF
--- a/src/katello/agent/pulp/libdnf.py
+++ b/src/katello/agent/pulp/libdnf.py
@@ -256,7 +256,7 @@ class Package(API):
             if advisories:
                 for ad, packages in lib.applicable_advisories(AdvisoryFilter(ids=advisories)):
                     for name, evr in packages:
-                        patterns.add(name)
+                        patterns.add(name + '-' + evr)
                 if patterns:
                    lib.upgrade(patterns)
             else:

--- a/test/test_katello/test_agent/test_pulp/test_libdnf.py
+++ b/test/test_katello/test_agent/test_pulp/test_libdnf.py
@@ -23,8 +23,9 @@ class TestLibDnf(unittest.TestCase):
         package = libdnf.Package()
         package.update([],advisories)
 
-        #strip the evrs out of the package
-        packages = set([pack[0] for pack in packages])
+        # ensure the packages have evrs included
+        # https://projects.theforeman.org/issues/35759
+        packages = set([pack[0] + '-' + pack[1] for pack in packages])
         mock_libdnf.upgrade.assert_called_with(packages)
 
   def test_package_update_all(self):


### PR DESCRIPTION
When installing an erratum via katello-agent on EL8 (with dnf), katello-agent tells libdnf to update the individual packages inside the erratum. Currently, it only passes the name, causing the latest RPM to be installed rather than the one in the erratum.  To fix this, I am appending the `evr` to the name to match the correct package.  The most ideal solution would be to use `dnf upgrade --minimal`, but `libdnf` doesn't seem to have Python bindings for that action.

To test:

1) `vagrant up rhel8` and register it to your Katello server.
2) Sync RHEL 8 AppStream + BaseOS.
3) Ensure that `tzdata-2022a-1.el8.noarch` and `tzdata-java-2022a-1.el8.noarch` are installed.
4) Locate the RHBA-2022:7067 and RHBA-2022:7404 errata in AppStream/BaseOS.  Note that the earlier one includes the `e` versions of the `tzdata` RPMs, and the latter one includes the `f` versions of the packages.
5) Install `katello-agent` on your RHEL 8 machine through the `satellite-client-6-for-rhel-8-x86_64-rpms` repo.
6) Apply the RHBA-2022:7067 erratum to your RHEL 8 machine and note that the wrong versions of the `tzdata` RPMs are installed: the `f` versions.
7) Rollback the `dnf update` from step (6).
8) Apply my patch to your RHEL 8 machine's katello-agent install. My related file was here:
```
/usr/lib/python3.6/site-packages/katello/agent/pulp/libdnf.py
```
9) Try the upgrade again and see that the proper `e` packages are installed.
10) Try this scenario on some other packages you can find with multiple errata.