### PR TITLE
Remove shebang from library

### DIFF
--- a/src/katello/scripts.py
+++ b/src/katello/scripts.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import optparse
 
 from katello.constants import (DISABLE_ENABLE_REPOS_VAR, DISABLE_PACKAGE_PROFILE_VAR,


### PR DESCRIPTION
This isn't needed and triggers dependencies in RPM packaging that shoulnd't be there.

Fixes: 8c5b6c1ece2ef7ff76d781a2d5a41443c9ea0845