### PR TITLE
Bump version to 4.4.0

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='katello-host-tools',
-    version='4.3.0',
+    version='4.4.0',
     description='Libraries and command-line utilities for keeping Katello clients in sync and up to date',
     author='The Foreman Project',
     author_email='no-email@theforeman.org',


### PR DESCRIPTION
The change to using dnf needs-restarting is pretty major, so I'm bumping the Y version.