### PR TITLE
Fixes #37377 - Add interop method for find_module

### DIFF
--- a/src/katello/constants.py
+++ b/src/katello/constants.py
@@ -1,4 +1,4 @@
-import imp
+from katello.find_module import find_module
 
 ENABLED_REPOS_CACHE_FILE = '/var/cache/katello-agent/enabled_repos.json'
 PACKAGE_CACHE_FILE = '/var/lib/rhsm/packages/packages.json'
@@ -13,13 +13,13 @@ DISABLE_ENABLE_REPOS_VAR = 'DISABLE_KATELLO_ENABLED_REPOS'
 PROFILE_CACHE_FILE = '/var/lib/rhsm/cache/profile.json'
 
 try:
-    imp.find_module('zypp_plugin')
+    find_module('zypp_plugin')
     ZYPPER = True
 except ImportError:
     ZYPPER = False
 
 try:
-    imp.find_module('yum')
+    find_module('yum')
     YUM = True
 except ImportError:
     YUM = False

--- a/src/katello/find_module.py
+++ b/src/katello/find_module.py
@@ -1,0 +1,10 @@
+def find_module(module_name):
+    try:
+        import importlib
+        module_spec = importlib.util.find_spec(module_name)
+        if module_spec is None:
+            raise ImportError("Module not found: {}".format(module_name))
+        return module_spec
+    except (ImportError, AttributeError):
+        import imp
+        return imp.find_module(module_name)

--- a/src/katello/tracer/__init__.py
+++ b/src/katello/tracer/__init__.py
@@ -1,18 +1,18 @@
 from __future__ import absolute_import
 from katello.uep import get_uep, lookup_consumer_id
 import sys
-import imp
+from katello.find_module import find_module
 
 def collect_apps():
     raise NotImplementedError("Couldn't detect package manager. Failed to query affected apps!")
 
 # RHEL based systems
 try:
-    imp.find_module('dnf')
+    find_module('dnf')
     from katello.tracer.dnf import collect_apps
 except ImportError:
     try:
-        imp.find_module('yum')
+        find_module('yum')
         from tracer.query import Query
         def collect_apps():
             query = Query()
@@ -22,14 +22,14 @@ except ImportError:
 
 # debian based systems
 try:
-    imp.find_module('apt')
+    find_module('apt')
     from katello.tracer.deb import collect_apps
 except ImportError:
     pass
 
 # SUSE based systems
 try:
-    imp.find_module('zypp_plugin')
+    find_module('zypp_plugin')
     from katello.tracer.zypper import collect_apps
 except ImportError:
     pass


### PR DESCRIPTION
In python2, only module "imp" exists.
In python3 the importlib module exists to check if a module exists.
