### PR TITLE
Fix katello-tracer-upload path. (Refs #137)

### DIFF
--- a/extra/81-tracer-upload-apt
+++ b/extra/81-tracer-upload-apt
@@ -1,1 +1,1 @@
-DPkg::Post-Invoke { /usr/bin/tracer-upload }
+DPkg::Post-Invoke { /sbin/katello-tracer-upload }

--- a/extra/katello-tracer-upload.cron
+++ b/extra/katello-tracer-upload.cron
@@ -1,2 +1,2 @@
 # Send a new Tracer report after a reboot
-@reboot root sleep 60 && PATH=/usr/sbin:/usr/bin:/sbin:/bin /sbin/katello-tracer-upload >/dev/null 2>&1
+@reboot root sleep 60 && PATH=/usr/sbin:/usr/bin:/sbin:/bin katello-tracer-upload >/dev/null 2>&1


### PR DESCRIPTION
The path to the tracer tool was adapted for EL variants: https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/client/katello-host-tools/katello-host-tools.spec#L398

This commit adapts the same for Debian. Additionally, if the PATH variable is set, it doesn't make sense to provide the path to the katello-tracer-upload script. 