### PR TITLE
Add CentOS 10, Debian 11 and openSUSE 15 tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,7 @@ jobs:
   containers:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dockerfile:
           - images/Dockerfile.el9

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         dockerfile:
+          - images/Dockerfile.el10
           - images/Dockerfile.el9
           - images/Dockerfile.el8
           - images/Dockerfile.el7

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         dockerfile:
+          - images/Dockerfile.debian11
           - images/Dockerfile.el10
           - images/Dockerfile.el9
           - images/Dockerfile.el8

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,7 @@ jobs:
           - images/Dockerfile.f34
           - images/Dockerfile.f33
           - images/Dockerfile.suseLeap42
+          - images/Dockerfile.suseLeap15
     steps:
       - uses: actions/checkout@v2
       - name: ${{ matrix.dockerfile }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,6 @@ jobs:
   containers:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
         dockerfile:
           - images/Dockerfile.el9

--- a/images/Dockerfile.debian11
+++ b/images/Dockerfile.debian11
@@ -1,0 +1,8 @@
+FROM debian:11
+
+RUN apt-get update && apt-get install --yes --no-install-recommends curl make python3 python3-pip python3-setuptools && apt-get clean
+RUN curl -o /etc/apt/trusted.gpg.d/atix.asc https://oss.atix.de/atix_gpg.pub
+RUN echo 'deb https://oss.atix.de/Debian11/ stable main' >> /etc/apt/sources.list
+RUN apt-get update && apt-get install --yes --no-install-recommends python3-subscription-manager && apt-get clean
+
+WORKDIR /app

--- a/images/Dockerfile.el10
+++ b/images/Dockerfile.el10
@@ -1,0 +1,4 @@
+FROM quay.io/centos/centos:stream10-development
+
+RUN dnf install make python3 python3-pip python3-setuptools python3-dnf-plugins-core subscription-manager -y && dnf clean all
+WORKDIR /app

--- a/images/Dockerfile.el7
+++ b/images/Dockerfile.el7
@@ -2,5 +2,5 @@ FROM quay.io/centos/centos:7
 
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g; /^#baseurl/ s/^#//; /baseurl/ s/mirror/vault/g' /etc/yum.repos.d/CentOS-Base.repo
 RUN yum install -y epel-release https://yum.theforeman.org/client/nightly/el7/x86_64/foreman-client-release.rpm && yum clean all
-RUN yum install make python-setuptools python-tracer subscription-manager python-pip python2-mock python-unittest2 -y && yum clean all
+RUN yum install make python-setuptools python-tracer subscription-manager python-pip python2-mock -y && yum clean all
 WORKDIR /app

--- a/images/Dockerfile.suseLeap15
+++ b/images/Dockerfile.suseLeap15
@@ -1,0 +1,8 @@
+FROM opensuse/leap:15
+
+RUN zypper addrepo -c --no-gpgcheck https://oss.atix.de/SLES15SP5/ subscription-manager
+RUN zypper removerepo 'OSS Update'
+RUN zypper clean --all
+RUN zypper install -y make python3-pip subscription-manager python3-zypp-plugin which python3-setuptools lsof
+
+WORKDIR /app

--- a/images/Dockerfile.suseLeap42
+++ b/images/Dockerfile.suseLeap42
@@ -1,6 +1,6 @@
 FROM opensuse/leap:42
 
-RUN zypper addrepo -c --no-gpgcheck http://download.opensuse.org/repositories/home:/kahowell/openSUSE_Leap_42.2/ subscription-manager
+RUN zypper addrepo -c --no-gpgcheck https://oss.atix.de/SLES12SP5/ subscription-manager
 RUN zypper removerepo 'OSS Update'
 RUN zypper clean --all
 RUN zypper install -y make python-pip subscription-manager zypp-plugin-python which python-setuptools lsof

--- a/src/katello/constants.py
+++ b/src/katello/constants.py
@@ -1,5 +1,3 @@
-import imp
-
 ENABLED_REPOS_CACHE_FILE = '/var/cache/katello-agent/enabled_repos.json'
 PACKAGE_CACHE_FILE = '/var/lib/rhsm/packages/packages.json'
 REPOSITORY_PATH = '/etc/yum.repos.d/redhat.repo'
@@ -13,13 +11,13 @@ DISABLE_ENABLE_REPOS_VAR = 'DISABLE_KATELLO_ENABLED_REPOS'
 PROFILE_CACHE_FILE = '/var/lib/rhsm/cache/profile.json'
 
 try:
-    imp.find_module('zypp_plugin')
+    import zypp_plugin
     ZYPPER = True
 except ImportError:
     ZYPPER = False
 
 try:
-    imp.find_module('yum')
+    import yum
     YUM = True
 except ImportError:
     YUM = False

--- a/src/katello/tracer/__init__.py
+++ b/src/katello/tracer/__init__.py
@@ -1,18 +1,17 @@
 from __future__ import absolute_import
 from katello.uep import get_uep, lookup_consumer_id
 import sys
-import imp
 
 def collect_apps():
     raise NotImplementedError("Couldn't detect package manager. Failed to query affected apps!")
 
 # RHEL based systems
 try:
-    imp.find_module('dnf')
+    import dnf
     from katello.tracer.dnf import collect_apps
 except ImportError:
     try:
-        imp.find_module('yum')
+        import yum
         from tracer.query import Query
         def collect_apps():
             query = Query()
@@ -22,14 +21,14 @@ except ImportError:
 
 # debian based systems
 try:
-    imp.find_module('apt')
+    import apt
     from katello.tracer.deb import collect_apps
 except ImportError:
     pass
 
 # SUSE based systems
 try:
-    imp.find_module('zypp_plugin')
+    import zypp_plugin
     from katello.tracer.zypper import collect_apps
 except ImportError:
     pass

--- a/src/katello/utils.py
+++ b/src/katello/utils.py
@@ -3,7 +3,11 @@ import os
 from os import environ
 
 if sys.version_info[0] == 3:
-    from configparser import ConfigParser
+    from configparser import ConfigParser as BaseConfigParser
+    class ConfigParser(BaseConfigParser):
+        def __init__(self, *args, **kwargs):
+            kwargs['interpolation'] = None
+            super(ConfigParser, self).__init__(*args, **kwargs)
 else:
     from ConfigParser import ConfigParser
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 flake8; python_version >= '3.6'
 mock<4.0.0; python_version >= '2.7'
-unittest2

--- a/test/dnf-plugins/test_tracer_upload.py
+++ b/test/dnf-plugins/test_tracer_upload.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 
+orig_path = list(sys.path)
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/dnf-plugins'))
 try:
@@ -10,6 +11,7 @@ try:
 except ImportError:
     class PluginTestCase:
         pass
+sys.path = orig_path
 
 from mock import Mock, patch
 

--- a/test/dnf-plugins/test_tracer_upload.py
+++ b/test/dnf-plugins/test_tracer_upload.py
@@ -1,11 +1,15 @@
 import os
 import sys
-from dnf_support import PluginTestCase, configure_command
 import unittest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/dnf-plugins'))
-import tracer_upload
+try:
+    from dnf_support import PluginTestCase, configure_command
+    import tracer_upload
+except ImportError:
+    class PluginTestCase:
+        pass
 
 from mock import Mock, patch
 
@@ -33,6 +37,7 @@ class TestTracerPlugin(PluginTestCase):
         assert not upload_tracer.called
 
 
+@unittest.skipIf('dnf' not in sys.modules, "DNF not present")
 class TestTracerUploadCommand(unittest.TestCase):
     def setUp(self):
         self.cli = Mock()

--- a/test/dnf-plugins/test_tracer_upload.py
+++ b/test/dnf-plugins/test_tracer_upload.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from dnf_support import PluginTestCase, configure_command
-import unittest2 as unittest
+import unittest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/dnf-plugins'))

--- a/test/dnf_support.py
+++ b/test/dnf_support.py
@@ -1,5 +1,5 @@
 from configparser import ConfigParser
-from unittest2 import TestCase
+from unittest import TestCase
 
 import dnf.cli.option_parser
 

--- a/test/test_katello/test_enabled_report.py
+++ b/test/test_katello/test_enabled_report.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import unittest2 as unittest
+import unittest
 from mock import patch
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
 from katello import enabled_report

--- a/test/test_katello/test_repos.py
+++ b/test/test_katello/test_repos.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-from unittest2 import TestCase
+from unittest import TestCase
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
 from katello import repos

--- a/test/test_katello/test_tracer/test_tracer.py
+++ b/test/test_katello/test_tracer/test_tracer.py
@@ -32,29 +32,18 @@ class TestUploadTracerProfile(unittest.TestCase):
 
 class TestQueryAffectedApps(unittest.TestCase):
     @unittest.skipIf(YUM == False, "Yum not present")
-    @patch('katello.tracer.yum', True)
-    @patch('katello.tracer.dnf', False)
     def test_el_os(self):
         self.assertEqual(query_affected_apps(), [])
 
     @unittest.skipIf(YUM == False, "YUM not present")
-    @patch('katello.tracer.yum', False)
-    @patch('katello.tracer.dnf', False)
-    @patch('katello.tracer.zypp', True)
     def test_failing_zypper_os(self):
         self.assertRaises(Exception, query_affected_apps)
 
     @unittest.skipIf(ZYPPER == False, "ZYPPER not present")
-    @patch('katello.tracer.yum', False)
-    @patch('katello.tracer.dnf', False)
-    @patch('katello.tracer.zypp', True)
     def test_zypper_os(self):
         self.assertEqual(query_affected_apps(), [])
 
     @unittest.skipIf(ZYPPER == False, "ZYPPER not present")
-    @patch('katello.tracer.yum', True)
-    @patch('katello.tracer.dnf', False)
-    @patch('katello.tracer.zypp', False)
     def test_failing_yum_os(self):
         self.assertRaises(Exception, query_affected_apps)
 

--- a/test/test_katello/test_tracer/test_tracer.py
+++ b/test/test_katello/test_tracer/test_tracer.py
@@ -35,15 +35,6 @@ class TestQueryAffectedApps(unittest.TestCase):
     def test_el_os(self):
         self.assertEqual(query_affected_apps(), [])
 
-    @unittest.skipIf(YUM == False, "YUM not present")
-    def test_failing_zypper_os(self):
-        self.assertRaises(Exception, query_affected_apps)
-
     @unittest.skipIf(ZYPPER == False, "ZYPPER not present")
     def test_zypper_os(self):
         self.assertEqual(query_affected_apps(), [])
-
-    @unittest.skipIf(ZYPPER == False, "ZYPPER not present")
-    def test_failing_yum_os(self):
-        self.assertRaises(Exception, query_affected_apps)
-

--- a/test/test_katello/test_tracer/test_tracer.py
+++ b/test/test_katello/test_tracer/test_tracer.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import unittest2 as unittest
+import unittest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
 from katello.tracer import upload_tracer_profile, query_affected_apps

--- a/test/test_yum_plugins/test_enabled_repos_upload.py
+++ b/test/test_yum_plugins/test_enabled_repos_upload.py
@@ -6,12 +6,14 @@ from rhsm.connection import RemoteServerException
 from mock import patch, Mock
 import unittest
 
+orig_path = list(sys.path)
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/yum-plugins'))
     import enabled_repos_upload
 except ImportError:
     print("Yum wasn't present")
+sys.path = orig_path
 
 
 FAKE_REPORT = {'foobar': 1}

--- a/test/test_yum_plugins/test_enabled_repos_upload.py
+++ b/test/test_yum_plugins/test_enabled_repos_upload.py
@@ -4,7 +4,7 @@ import sys
 from rhsm.connection import RemoteServerException
 
 from mock import patch, Mock
-import unittest2 as unittest
+import unittest
 
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))

--- a/test/unittest_suite.py
+++ b/test/unittest_suite.py
@@ -2,7 +2,7 @@
 
 import sys
 
-import unittest2 as unittest
+import unittest
 
 
 if sys.version_info[0] == 2:

--- a/test/zypper_plugins/test_enabled_repos_upload.py
+++ b/test/zypper_plugins/test_enabled_repos_upload.py
@@ -1,8 +1,7 @@
 import os
 import sys
 
-from unittest2 import TestCase
-import unittest2 as unittest
+import unittest
 from mock import Mock, patch
 
 try:
@@ -12,7 +11,7 @@ try:
 except:
   pass
 
-class TestEnabledReposUpload(TestCase):
+class TestEnabledReposUpload(unittest.TestCase):
     def setUp(self):
         self.plugin = enabled_repos_upload.EnabledReposUpload()
 

--- a/test/zypper_plugins/test_enabled_repos_upload.py
+++ b/test/zypper_plugins/test_enabled_repos_upload.py
@@ -4,12 +4,14 @@ import sys
 import unittest
 from mock import Mock, patch
 
+orig_path = list(sys.path)
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/zypper_plugins'))
     import enabled_repos_upload
 except:
-  pass
+    pass
+sys.path = orig_path
 
 class TestEnabledReposUpload(unittest.TestCase):
     def setUp(self):

--- a/test/zypper_plugins/test_package_upload.py
+++ b/test/zypper_plugins/test_package_upload.py
@@ -1,8 +1,7 @@
 import os
 import sys
 
-from unittest2 import TestCase
-import unittest2 as unittest
+import unittest
 from mock import Mock, patch
 
 try:
@@ -12,7 +11,7 @@ try:
 except:
   pass
 
-class TestPackageUpload(TestCase):
+class TestPackageUpload(unittest.TestCase):
     def setUp(self):
         self.plugin = package_upload.KatelloZyppPlugin()
 

--- a/test/zypper_plugins/test_tracer_upload.py
+++ b/test/zypper_plugins/test_tracer_upload.py
@@ -4,12 +4,14 @@ import sys
 import unittest
 from mock import Mock, patch
 
+orig_path = list(sys.path)
 try:
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/'))
     sys.path.append(os.path.join(os.path.dirname(__file__), '../../src/zypper_plugins'))
     import tracer_upload
 except:
     pass
+sys.path = orig_path
 
 class TestTracerUpload(unittest.TestCase):
     def setUp(self):

--- a/test/zypper_plugins/test_tracer_upload.py
+++ b/test/zypper_plugins/test_tracer_upload.py
@@ -1,8 +1,7 @@
 import os
 import sys
 
-from unittest2 import TestCase
-import unittest2 as unittest
+import unittest
 from mock import Mock, patch
 
 try:
@@ -12,7 +11,7 @@ try:
 except:
     pass
 
-class TestTracerUpload(TestCase):
+class TestTracerUpload(unittest.TestCase):
     def setUp(self):
         self.plugin = tracer_upload.TracerUploadPlugin()
 


### PR DESCRIPTION
- **don't set max-parallel 1, run all the tests in parallel**
- **fail-fast: false - run all tests even if some fail**
- **add EL10 testing**
- **use native unittest, unittest2 was a backport for pre 2.7 python**
- **stop using deprecated imp -- import and ImportError is enough**
- **properly skip DNF related tests when DNF is not available**
- **Add Debian 11 tests**
