### PR TITLE
Unconditionally test Zypper cases from TestEnabledReport

### DIFF
--- a/test/test_katello/test_enabled_report.py
+++ b/test/test_katello/test_enabled_report.py
@@ -21,8 +21,8 @@ class TestEnabledReport(unittest.TestCase):
 
         self.assertEqual(expected, report.content)
 
-    @unittest.skipIf(ZYPPER == False, "Zypper not present")
     @patch('katello.enabled_report.YUM', False)
+    @patch('katello.enabled_report.ZYPPER', True)
     def test_zypper_valid(self):
         rh_repo = os.path.join(os.path.dirname(__file__), 'data/repos/redhat.repo.suse')
         report = enabled_report.EnabledReport(rh_repo)


### PR DESCRIPTION
The code isn't dependent on Zypper itself and our CI doesn't run on SuSE so this gives better test coverage.